### PR TITLE
Allow providing ZIP http URLs along with filesystem path for test suites

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -18,15 +18,28 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+
       - name: Initialize node.js environment
         uses: actions/setup-node@v3
         with:
           node-version: 16
+
       - name: Build tests
         working-directory: tests/assemblyscript
         run: |
           npm install
           npm run build
+
+      - name: Upload precompiled tests
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: assemblyscript-testsuite
+          path: |
+            tests/assemblyscript/testsuite/*.wasm
+            tests/assemblyscript/testsuite/*.json
+          if-no-files-found: error
+
   build_c:
     name: Build C tests
     runs-on: ${{ matrix.os }}
@@ -38,29 +51,84 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+
       - name: Setup WASI SDK download - Linux
         if: matrix.os == 'ubuntu-latest'
         run: echo SYSTEM_NAME=linux >> $GITHUB_ENV
+
       - name: Setup WASI SDK download - MacOS
         if: matrix.os == 'macos-latest'
         run: echo SYSTEM_NAME=macos >> $GITHUB_ENV
+
       - name: Setup WASI SDK download - Windows
         if: matrix.os == 'windows-latest'
         run: echo SYSTEM_NAME=mingw >> $env:GITHUB_ENV
+
       - name: Download WASI SDK
         working-directory: tests/c
         shell: bash
         run: curl -L -f https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION}.0-${SYSTEM_NAME}.tar.gz --output wasi-sdk.tar.gz
+
       - name: Install WASI SDK
         working-directory: tests/c
         shell: bash
         run: tar xvf wasi-sdk.tar.gz
+
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'
         working-directory: tests/c
         run: find testsuite -regex '.*\.\(c\|h\)' -print0 | xargs -0 -n1 ./wasi-sdk-${WASI_VERSION}.0/bin/clang-format --style=file --dry-run -Werror
+
       - name: Build tests
         shell: bash
         working-directory: tests/c
-        run: CC="./wasi-sdk-${WASI_VERSION}.0/bin/clang" ./build.sh
+        run: CC=./wasi-sdk-${WASI_VERSION}.0/bin/clang ./build.sh
 
+      - name: Upload precompiled tests
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: c-testsuite
+          path: |
+            tests/c/testsuite/*.wasm
+            tests/c/testsuite/*.json
+          if-no-files-found: error
+
+  upload_test_binaries:
+    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    needs: [build_assemblyscript, build_c]
+    strategy:
+      max-parallel: 1
+      matrix:
+        suite: [assemblyscript, c]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download ${{ matrix.suite }} tests
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.suite }}-testsuite
+          path: ${{ matrix.suite }}-testsuite
+
+      # Git checkout needs to be executed before creating archive to avoid
+      # conflicts
+      - name: Setup git
+        run: |
+          git checkout precompiled-tests
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: Create archive
+        run: |
+          mkdir -p suites
+          zip -FS suites/${{ matrix.suite }}-testsuite.zip ${{ matrix.suite }}-testsuite/*
+
+      - name: Publish archive
+        run: |
+          git add suites/${{ matrix.suite }}-testsuite.zip
+          git commit -m "Update ${{ matrix.suite }} test suite"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.wasm
+_test_cache/
 .DS_Store

--- a/test-runner/tests/test_test_suite_location.py
+++ b/test-runner/tests/test_test_suite_location.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock, patch
+import pytest
+import wasi_test_runner.test_suite_location as tsl
+
+
+def test_get_location_invalid_config_should_raise_error() -> None:
+    with pytest.raises(ValueError):
+        tsl.get_test_suite_location("non-existing-path")
+
+    with pytest.raises(ValueError):
+        tsl.get_test_suite_location("invalid-protocol://unsupported")
+
+
+@patch("os.path.isdir", Mock(return_value=True))
+@patch("wasi_test_runner.test_suite_location.file_system_test_suite_location")
+def test_get_location_existing_path_should_return_correct_location(
+    location_mock: Mock,
+) -> None:
+    path = "existing_path"
+    location_mock.return_value = path
+
+    assert path == tsl.get_test_suite_location(path)()
+
+    location_mock.assert_called_once_with(path)
+
+
+@patch("wasi_test_runner.test_suite_location.http_zip_test_suite_location")
+def test_get_location_http_should_return_correct_location(
+    location_mock: Mock,
+) -> None:
+    url = "http://my-url.com/test.zip"
+    path = "some-path"
+    location_mock.return_value = path
+
+    assert path == tsl.get_test_suite_location(url)()
+
+    location_mock.assert_called_once_with(url)

--- a/test-runner/wasi_test_runner/__main__.py
+++ b/test-runner/wasi_test_runner/__main__.py
@@ -3,6 +3,7 @@ import sys
 from typing import List
 
 
+from .test_suite_location import get_test_suite_location
 from .runtime_adapter import RuntimeAdapter
 from .harness import run_all_tests
 from .reporters import TestReporter
@@ -21,7 +22,7 @@ def main() -> int:
         "--test-suite",
         required=True,
         nargs="+",
-        help="Locations of suites (directories with *.wasm test files).",
+        help="Locations of suites (directories with *.wasm test files or urls to ZIP archives).",
     )
     parser.add_argument(
         "-r", "--runtime-adapter", required=True, help="Path to a runtime adapter."
@@ -47,7 +48,7 @@ def main() -> int:
 
     return run_all_tests(
         RuntimeAdapter(options.runtime_adapter),
-        options.test_suite,
+        [get_test_suite_location(suite) for suite in options.test_suite],
         validators,
         reporters,
     )

--- a/test-runner/wasi_test_runner/harness.py
+++ b/test-runner/wasi_test_runner/harness.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from .test_suite_location import TestSuiteLocation
 from .reporters import TestReporter
 from .test_suite_runner import run_tests_from_test_suite
 from .runtime_adapter import RuntimeAdapter
@@ -8,15 +9,15 @@ from .validators import Validator
 
 def run_all_tests(
     runtime: RuntimeAdapter,
-    test_suite_paths: List[str],
+    test_suite_locations: List[TestSuiteLocation],
     validators: List[Validator],
     reporters: List[TestReporter],
 ) -> int:
     ret = 0
 
-    for test_suite_path in test_suite_paths:
+    for test_suite_location in test_suite_locations:
         test_suite = run_tests_from_test_suite(
-            test_suite_path, runtime, validators, reporters
+            test_suite_location(), runtime, validators, reporters
         )
         for reporter in reporters:
             reporter.report_test_suite(test_suite)

--- a/test-runner/wasi_test_runner/test_suite_location.py
+++ b/test-runner/wasi_test_runner/test_suite_location.py
@@ -1,0 +1,53 @@
+import os
+
+from hashlib import sha1
+from io import BytesIO
+from typing import Callable
+from urllib.parse import urlparse
+from urllib.request import urlopen
+from zipfile import ZipFile
+
+
+TestSuiteLocation = Callable[[], str]
+
+
+def file_system_test_suite_location(path: str) -> str:
+    return path
+
+
+def http_zip_test_suite_location(url: str) -> str:
+    dirname = f"wasi-tests-{sha1(url.encode(encoding='UTF-8')).hexdigest()[:7]}"
+    extract_path = os.path.join("_test_cache", dirname)
+
+    if not os.path.exists(extract_path):
+        with ZipFile(BytesIO(urlopen(url).read())) as zip_file:
+            zip_file.extractall(extract_path)
+
+    subdirs = list(
+        filter(
+            os.path.isdir,
+            map(lambda p: os.path.join(extract_path, p), os.listdir(extract_path)),
+        )
+    )
+
+    if len(subdirs) != 1:
+        raise RuntimeError(
+            f"Expected a single directory in a zip archive, have: {subdirs}"
+        )
+
+    return subdirs[0]
+
+
+def get_test_suite_location(config: str) -> TestSuiteLocation:
+    if os.path.isdir(config):
+        return lambda: file_system_test_suite_location(config)
+
+    if _is_http_url(config):
+        return lambda: http_zip_test_suite_location(config)
+
+    raise ValueError(f"Unsupported configuration string {config}")
+
+
+def _is_http_url(path: str) -> bool:
+    ret = urlparse(path)
+    return ret.scheme in ["http", "https"] and len(ret.netloc) > 0


### PR DESCRIPTION
This change enables test runner to download ZIP archive with precompiled test cases and execute them. We won't upload precompiled wasm files to the main branch of the repository to keep the size of the repo small; we'll generate ZIP archives with precompiled tests and publish them as part of CI job.
