### PR TITLE
Add an adapter for WAMR

### DIFF
--- a/adapters/wasm-micro-runtime.sh
+++ b/adapters/wasm-micro-runtime.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# WARNING: this adapter assumes iwasm from the latest wasm-micro-runtime.
+# Namely the change to propagate WASI exit code:
+# https://github.com/bytecodealliance/wasm-micro-runtime/pull/1748
+
+TEST_FILE=
+ARGS=()
+DIR=()
+ENV=()
+
+IWASM=iwasm
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --version)
+        ${IWASM} --version
+        exit 0
+        ;;
+    --test-file)
+        TEST_FILE="$2"
+        shift
+        shift
+        ;;
+    --arg)
+        ARGS+=("$2")
+        shift
+        shift
+        ;;
+    --dir)
+        DIR+=("--dir=$2")
+        shift
+        shift
+        ;;
+    --env)
+        ENV+=("--env=$2")
+        shift
+        shift
+        ;;
+    *)
+        echo "Unknown option $1"
+        exit 1
+        ;;
+    esac
+done
+
+${IWASM} "${DIR[@]}" "${ENV[@]}" ${TEST_FILE} "${ARGS[@]}"


### PR DESCRIPTION
```
(venv) spacetanuki% python3 test-runner/wasi_test_runner.py -t tests/assemblyscript/testsuite tests/c/testsuite -r adapters/wasm-micro-runtime.sh
Test environ_get-multiple-variables passed
Test fd_write-to-invalid-fd passed
Test environ_sizes_get-multiple-variables passed
Test args_sizes_get-no-arguments passed
Test args_get-multiple-arguments passed
Test args_sizes_get-multiple-arguments passed
Test fd_write-to-stdout passed
Test random_get-non-zero-length passed
Test environ_sizes_get-no-variables passed
Test random_get-zero-length passed
Test clock_getres-realtime passed
Test clock_gettime-monotonic passed
Test clock_getres-monotonic passed
Test clock_gettime-realtime passed

===== Test results =====
Runtime: iwasm v1.0.0
Suite: WASI Assemblyscript tests
  Total: 10
  Passed:  10
  Failed:  0

Suite: WASI C tests
  Total: 4
  Passed:  4
  Failed:  0

Test suites: 2 passed, 0 total
Tests:       14 passed, 0 total
(venv) spacetanuki%
```