### PR TITLE
proc_exit-failure: use a bit more awkward exit code

### DIFF
--- a/tests/assemblyscript/testsuite/proc_exit-failure.json
+++ b/tests/assemblyscript/testsuite/proc_exit-failure.json
@@ -1,3 +1,3 @@
 {
-    "exit_code": 1
+    "exit_code": 33
 }

--- a/tests/assemblyscript/testsuite/proc_exit-failure.ts
+++ b/tests/assemblyscript/testsuite/proc_exit-failure.ts
@@ -2,5 +2,5 @@ import {
     proc_exit
 } from '@assemblyscript/wasi-shim/assembly/bindings/wasi_snapshot_preview1';
 
-  proc_exit(1);
+  proc_exit(33);
   unreachable();


### PR DESCRIPTION
The exit code 1 is too generic:

* many of platforms have EXIT_FAILURE == 1.

* many of wasm engines exit with 1 on a unreachable trap. eg. wasm3 iwasm (wasm-micro-runtime) wasmer toywasm wasm-interp (wabt) wasmedge

  Note: wasmtime using 134 is an exception.

Use a bit more awkward value instead to avoid succeeding with a luck.