### PR TITLE
Do not prefix a version with "v"

### DIFF
--- a/test-runner/wasi_test_runner/reporters/console.py
+++ b/test-runner/wasi_test_runner/reporters/console.py
@@ -38,7 +38,7 @@ class ConsoleTestReporter(TestReporter):
     def finalize(self, version: RuntimeVersion) -> None:
         print("")
         print("===== Test results =====")
-        print(f"Runtime: {version.name} v{version.version}")
+        print(f"Runtime: {version.name} {version.version}")
 
         total_skip = total_pass = total_fail = pass_suite = 0
 


### PR DESCRIPTION
The "v" prefix doesn't always make sense.
We should not assume much in versioning schemes used by runtimes.