### PR TITLE
Update to wasi 0.11.

### DIFF
--- a/tests/rust/Cargo.lock
+++ b/tests/rust/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi_tests"

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.65"
-wasi = "0.10.2"
+wasi = "0.11.0"
 once_cell = "1.12"

--- a/tests/rust/src/bin/close_preopen.rs
+++ b/tests/rust/src/bin/close_preopen.rs
@@ -8,17 +8,14 @@ unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
 
     // Try to close a preopened directory handle.
     assert_errno!(
-        wasi::fd_close(pre_fd)
-            .expect_err("closing a preopened file descriptor")
-            .raw_error(),
+        wasi::fd_close(pre_fd).expect_err("closing a preopened file descriptor"),
         wasi::ERRNO_NOTSUP
     );
 
     // Try to renumber over a preopened directory handle.
     assert_errno!(
         wasi::fd_renumber(dir_fd, pre_fd)
-            .expect_err("renumbering over a preopened file descriptor")
-            .raw_error(),
+            .expect_err("renumbering over a preopened file descriptor"),
         wasi::ERRNO_NOTSUP
     );
 
@@ -33,8 +30,7 @@ unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
     // Try to renumber a preopened directory handle.
     assert_errno!(
         wasi::fd_renumber(pre_fd, dir_fd)
-            .expect_err("renumbering over a preopened file descriptor")
-            .raw_error(),
+            .expect_err("renumbering over a preopened file descriptor"),
         wasi::ERRNO_NOTSUP
     );
 

--- a/tests/rust/src/bin/dangling_fd.rs
+++ b/tests/rust/src/bin/dangling_fd.rs
@@ -9,8 +9,7 @@ unsafe fn test_dangling_fd(dir_fd: wasi::Fd) {
         // and then try creating it again
         let fd = wasi::path_open(dir_fd, 0, FILE_NAME, wasi::OFLAGS_CREAT, 0, 0, 0).unwrap();
         wasi::fd_close(fd).unwrap();
-        let file_fd =
-            wasi::path_open(dir_fd, 0, FILE_NAME, 0, 0, 0, 0).expect("failed to open");
+        let file_fd = wasi::path_open(dir_fd, 0, FILE_NAME, 0, 0, 0, 0).expect("failed to open");
         assert!(
             file_fd > libc::STDERR_FILENO as wasi::Fd,
             "file descriptor range check",
@@ -21,9 +20,8 @@ unsafe fn test_dangling_fd(dir_fd: wasi::Fd) {
 
         // Now, repeat the same process but for a directory
         wasi::path_create_directory(dir_fd, DIR_NAME).expect("failed to create dir");
-        let subdir_fd =
-            wasi::path_open(dir_fd, 0, DIR_NAME, wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-                .expect("failed to open dir");
+        let subdir_fd = wasi::path_open(dir_fd, 0, DIR_NAME, wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+            .expect("failed to open dir");
         assert!(
             subdir_fd > libc::STDERR_FILENO as wasi::Fd,
             "file descriptor range check",

--- a/tests/rust/src/bin/dangling_symlink.rs
+++ b/tests/rust/src/bin/dangling_symlink.rs
@@ -10,8 +10,7 @@ unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
         // Try to open it as a directory with O_NOFOLLOW.
         assert_errno!(
             wasi::path_open(dir_fd, 0, SYMLINK_NAME, wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-                .expect_err("opening a dangling symlink as a directory")
-                .raw_error(),
+                .expect_err("opening a dangling symlink as a directory"),
             wasi::ERRNO_NOTDIR,
             wasi::ERRNO_LOOP
         );
@@ -19,8 +18,7 @@ unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
         // Try to open it as a file with O_NOFOLLOW.
         assert_errno!(
             wasi::path_open(dir_fd, 0, SYMLINK_NAME, 0, 0, 0, 0)
-                .expect_err("opening a dangling symlink as a file")
-                .raw_error(),
+                .expect_err("opening a dangling symlink as a file"),
             wasi::ERRNO_LOOP
         );
 

--- a/tests/rust/src/bin/directory_seek.rs
+++ b/tests/rust/src/bin/directory_seek.rs
@@ -24,9 +24,7 @@ unsafe fn test_directory_seek(dir_fd: wasi::Fd) {
 
     // Attempt to seek.
     assert_errno!(
-        wasi::fd_seek(fd, 0, wasi::WHENCE_CUR)
-            .expect_err("seek on a directory")
-            .raw_error(),
+        wasi::fd_seek(fd, 0, wasi::WHENCE_CUR).expect_err("seek on a directory"),
         wasi::ERRNO_ISDIR,
         wasi::ERRNO_NOTCAPABLE,
         wasi::ERRNO_BADF

--- a/tests/rust/src/bin/fd_filestat_get.rs
+++ b/tests/rust/src/bin/fd_filestat_get.rs
@@ -1,5 +1,4 @@
 unsafe fn test_fd_filestat_get() {
-
     let stat = wasi::fd_filestat_get(libc::STDIN_FILENO as u32).expect("failed filestat 0");
     assert_eq!(stat.size, 0, "stdio size should be 0");
     assert_eq!(stat.atim, 0, "stdio atim should be 0");

--- a/tests/rust/src/bin/fd_readdir.rs
+++ b/tests/rust/src/bin/fd_readdir.rs
@@ -240,7 +240,5 @@ fn main() {
     unsafe { test_fd_readdir(dir_fd) }
     unsafe { test_fd_readdir_lots(dir_fd) }
 
-    unsafe {
-        wasi::path_remove_directory(base_dir_fd, DIR_NAME).expect("failed to remove dir")
-    }
+    unsafe { wasi::path_remove_directory(base_dir_fd, DIR_NAME).expect("failed to remove dir") }
 }

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -18,7 +18,7 @@ pub fn open_scratch_directory(path: &str) -> Result<wasi::Fd, String> {
                 Ok(s) => s,
                 Err(_) => break,
             };
-            if stat.tag != wasi::PREOPENTYPE_DIR {
+            if stat.tag != wasi::PREOPENTYPE_DIR.raw() {
                 continue;
             }
             let mut dst = Vec::with_capacity(stat.u.dir.pr_name_len);
@@ -122,8 +122,8 @@ macro_rules! assert_errno {
             }
             assert!( $( e == $i || )+ false,
                 "expected errno {}; got {}",
-                Alt(&[ $( wasi::errno_name($i) ),+ ]),
-                wasi::errno_name(e),
+                Alt(&[ $( $i.name() ),+ ]),
+                e.name(),
             )
         }
     };


### PR DESCRIPTION
This ports bytecodealliance/wasmtime#5488 to the wasi-testsuite repo. There should be no significant behavior changes here, just slightly tidier APIs.