### PR TITLE
Fix daily test run, add Rust

### DIFF
--- a/.github/workflows/daily-runtime-validation.yml
+++ b/.github/workflows/daily-runtime-validation.yml
@@ -54,7 +54,8 @@ jobs:
             -r ./adapters/${{ matrix.runtime }}.py \
             --json-output-location results.json \
             -t tests/assemblyscript/testsuite \
-            -t tests/c/testsuite
+               tests/rust/testsuite \
+               tests/c/testsuite
 
       - name: Configure git
         uses: ./.github/actions/git-config


### PR DESCRIPTION
The configuration of the daily action only runs the C suite, because a repeated `-t` only takes the last given list of arguments. The solution is _not_ repeating the `-t` arg. I also noticed that the daily run is missing Rust, so I am adding that too.

Should address #60

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
