### PR TITLE
Fix tests on WAMR

### DIFF
--- a/tests/rust/src/bin/interesting_paths.rs
+++ b/tests/rust/src/bin/interesting_paths.rs
@@ -16,7 +16,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     assert_errno!(
         wasi::path_open(dir_fd, 0, "/dir/nested/file", 0, 0, 0, 0)
             .expect_err("opening a file with an absolute path"),
-        wasi::ERRNO_PERM
+        wasi::ERRNO_PERM,
+        wasi::ERRNO_NOTCAPABLE
     );
 
     // Now open it with a path containing "..".
@@ -83,7 +84,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     assert_errno!(
         wasi::path_open(dir_fd, 0, &bad_path, 0, 0, 0, 0)
             .expect_err("opening a file with too many \"..\"s in the path should fail"),
-        wasi::ERRNO_PERM
+        wasi::ERRNO_PERM,
+        wasi::ERRNO_NOTCAPABLE
     );
     wasi::path_unlink_file(dir_fd, "dir/nested/file")
         .expect("unlink_file on a symlink should succeed");

--- a/tests/rust/src/bin/path_link.rs
+++ b/tests/rust/src/bin/path_link.rs
@@ -184,7 +184,8 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
                 "link",
             )
             .expect_err("calling path_link with LOOKUPFLAGS_SYMLINK_FOLLOW should fail"),
-            wasi::ERRNO_INVAL
+            wasi::ERRNO_INVAL,
+            wasi::ERRNO_NOENT
         );
 
         wasi::path_unlink_file(dir_fd, "symlink").expect("removing a symlink");

--- a/tests/rust/src/bin/path_open_dirfd_not_dir.rs
+++ b/tests/rust/src/bin/path_open_dirfd_not_dir.rs
@@ -9,7 +9,8 @@ unsafe fn test_dirfd_not_dir(dir_fd: wasi::Fd) {
     assert_errno!(
         wasi::path_open(file_fd, 0, "foo", wasi::OFLAGS_CREAT, 0, 0, 0)
             .expect_err("non-directory base fd should get ERRNO_NOTDIR"),
-        wasi::ERRNO_NOTDIR
+        wasi::ERRNO_NOTDIR,
+        wasi::ERRNO_NOTCAPABLE
     );
     wasi::fd_close(file_fd).expect("closing a file");
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");

--- a/tests/rust/src/bin/path_symlink_trailing_slashes.rs
+++ b/tests/rust/src/bin/path_symlink_trailing_slashes.rs
@@ -43,7 +43,8 @@ unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
         wasi::path_symlink("source", dir_fd, "target/")
             .expect_err("link destination already exists"),
         unix => wasi::ERRNO_NOTDIR,
-        windows => wasi::ERRNO_NOENT
+        windows => wasi::ERRNO_NOENT,
+        wasi::ERRNO_EXIST
     );
     wasi::path_unlink_file(dir_fd, "target").expect("removing a file");
 

--- a/tests/rust/src/bin/renumber.rs
+++ b/tests/rust/src/bin/renumber.rs
@@ -71,6 +71,14 @@ unsafe fn test_renumber(dir_fd: wasi::Fd) {
         "expected fd_to have the same fdstat as fd_from"
     );
 
+    // Try renumbering to an invalid destination fd (fd_from is invalid at this point)
+    assert_errno!(
+        wasi::fd_renumber(fd_to, fd_from).expect_err(
+            "fd_renumber should not allow renumbering to invalid destination file descriptors",
+        ),
+        wasi::ERRNO_BADF
+    );
+
     wasi::fd_close(fd_to).expect("closing a file");
 
     wasi::path_unlink_file(dir_fd, "file1").expect("removing a file");

--- a/tests/rust/src/bin/stdio.rs
+++ b/tests/rust/src/bin/stdio.rs
@@ -1,13 +1,49 @@
-use wasi_tests::{STDERR_FD, STDIN_FD, STDOUT_FD};
+use std::{env, process};
 
-unsafe fn test_stdio() {
-    for fd in &[STDIN_FD, STDOUT_FD, STDERR_FD] {
-        wasi::fd_fdstat_get(*fd).expect("fd_fdstat_get on stdio");
-        wasi::fd_renumber(*fd, *fd + 100).expect("renumbering stdio");
+use wasi_tests::{create_tmp_dir, open_scratch_directory, STDERR_FD, STDIN_FD, STDOUT_FD};
+
+const TEST_FILENAME: &'static str = "file.cleanup";
+
+unsafe fn test_stdio(dir_fd: wasi::Fd) {
+    for stdio_from_fd in &[STDIN_FD, STDOUT_FD, STDERR_FD] {
+        let stdio_to_fd = wasi::path_open(dir_fd, 0, TEST_FILENAME, wasi::OFLAGS_CREAT, 0, 0, 0)
+            .expect("open file");
+
+        wasi::fd_renumber(*stdio_from_fd, stdio_to_fd).expect("renumbering stdio");
+
+        wasi::fd_fdstat_get(stdio_to_fd).expect("fd_fdstat_get failed");
+        wasi::fd_fdstat_get(*stdio_from_fd).expect_err("stdio_from_fd is not closed");
+
+        // Cleanup
+        wasi::path_unlink_file(dir_fd, "file").expect("failed to remove file");
     }
 }
 
 fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    let base_dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    const DIR_NAME: &str = "stdio_dir.cleanup";
+    let dir_fd;
+    unsafe {
+        dir_fd = create_tmp_dir(base_dir_fd, DIR_NAME);
+    }
     // Run the tests.
-    unsafe { test_stdio() }
+    unsafe { test_stdio(dir_fd) }
+
+    unsafe { wasi::path_remove_directory(base_dir_fd, DIR_NAME).expect("failed to remove dir") }
 }

--- a/tests/rust/src/bin/truncation_rights.rs
+++ b/tests/rust/src/bin/truncation_rights.rs
@@ -67,7 +67,8 @@ unsafe fn test_truncation_rights(dir_fd: wasi::Fd) {
         assert_errno!(
             wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_TRUNC, 0, 0, 0)
                 .expect_err("truncating a file without path_filestat_set_size right"),
-            wasi::ERRNO_PERM
+            wasi::ERRNO_PERM,
+            wasi::ERRNO_NOTCAPABLE
         );
     }
 

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -39,6 +39,11 @@ pub unsafe fn create_tmp_dir(dir_fd: wasi::Fd, name: &str) -> wasi::Fd {
             | wasi::RIGHTS_FD_READDIR
             | wasi::RIGHTS_FD_FILESTAT_GET
             | wasi::RIGHTS_FD_SEEK
+            | wasi::RIGHTS_PATH_LINK_SOURCE
+            | wasi::RIGHTS_PATH_LINK_TARGET
+            | wasi::RIGHTS_PATH_OPEN
+            | wasi::RIGHTS_PATH_UNLINK_FILE
+            | wasi::RIGHTS_PATH_FILESTAT_GET
             | wasi::RIGHTS_FD_FDSTAT_SET_FLAGS
             | wasi::RIGHTS_FD_SYNC
             | wasi::RIGHTS_FD_TELL

--- a/tests/rust/testsuite/stdio.json
+++ b/tests/rust/testsuite/stdio.json
@@ -1,0 +1,4 @@
+{
+    "dirs": ["fs-tests.dir"],
+    "args": ["fs-tests.dir"]
+}


### PR DESCRIPTION
Most of the changes are adding rights to fix permissions issues and changing expected error codes.

I've also changed the `stdio.rs` test so that the destination (`to`) file descriptors are valid. The test was previously failing on WAMR since the destination fd's were arbitrary numbers which seems to be explicitly not permitted by the [docs](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/witx/wasi_snapshot_preview1.witx#L245-L251). A test case has been added in `renumber.rs` to enforce that renumbering to invalid destination file descriptors is an error.

If we want to align on return error codes between the runtimes for certain filesystem functions, I don't think it would be too much work to change the WAMR implementation to make it fall in line with wasmtime but for the moment have raised this PR to get some clarification and feedback.