### PR TITLE
revert local override on no_fdflags_sync_support

### DIFF
--- a/tests/rust/src/config.rs
+++ b/tests/rust/src/config.rs
@@ -27,11 +27,7 @@ impl TestConfig {
         let no_dangling_filesystem = std::env::var("NO_DANGLING_FILESYSTEM").is_ok();
         let no_fd_allocate = std::env::var("NO_FD_ALLOCATE").is_ok();
         let no_rename_dir_to_empty_dir = std::env::var("NO_RENAME_DIR_TO_EMPTY_DIR").is_ok();
-
-        // Disable the sync tests while we determine whether these will be
-        // included in the standard: <https://github.com/WebAssembly/wasi-filesystem/issues/98>
-        //let no_fdflags_sync_support = std::env::var("NO_FDFLAGS_SYNC_SUPPORT").is_ok();
-        let no_fdflags_sync_support = true;
+        let no_fdflags_sync_support = std::env::var("NO_FDFLAGS_SYNC_SUPPORT").is_ok();
 
         TestConfig {
             errno_mode,


### PR DESCRIPTION
* I couldn't find this in wasmtime repo. I suppose this was a local modification done as a part of https://github.com/WebAssembly/wasi-testsuite/pull/68

* As some implementations have implemented it, it isn't appropriate to assert NOTSUP by default.