### PR TITLE
Add expected error code for fd_prestat_dir_name

### DIFF
--- a/tests/rust/src/bin/dir_fd_op_failures.rs
+++ b/tests/rust/src/bin/dir_fd_op_failures.rs
@@ -13,8 +13,12 @@ unsafe fn test_fd_dir_ops(dir_fd: wasi::Fd) {
         .expect("failed to find preopen directory");
 
     let mut pr_name = vec![];
-    let r = wasi::fd_prestat_dir_name(pr_fd, pr_name.as_mut_ptr(), 0);
-    assert_eq!(r, Err(wasi::ERRNO_NAMETOOLONG));
+    assert_errno!(
+        wasi::fd_prestat_dir_name(pr_fd, pr_name.as_mut_ptr(), 0)
+            .expect_err("fd_prestat_dir_name error"),
+        wasi::ERRNO_INVAL,
+        wasi::ERRNO_NAMETOOLONG
+    );
 
     // Test that passing a larger than necessary buffer works correctly
     let mut pr_name = vec![0; pr_name_len + 1];


### PR DESCRIPTION
In the case that the user provides a buffer which is too small to fit the directory name, it makes more sense to return EINVAL rather than ENAMETOOLONG. ENAMETOOLONG has the speficic connotation that a path was longer than the maximum size permitted by the OS - that doesn't really match this error condition. We're keeping both error codes for now since we don't specify in the docs what error code should be returned.