### PR TITLE
Add tests for sock_shutdown() API

### DIFF
--- a/tests/c/testsuite/sock_shutdown-invalid_fd.c
+++ b/tests/c/testsuite/sock_shutdown-invalid_fd.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+
+int main() {
+  int fd = 3;
+  assert(shutdown(fd, SHUT_RD) != 0);
+  assert(errno == EBADF);
+
+  return EXIT_SUCCESS;
+}

--- a/tests/c/testsuite/sock_shutdown-not_sock.c
+++ b/tests/c/testsuite/sock_shutdown-not_sock.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main() {
+  assert(shutdown(STDOUT_FILENO, SHUT_RD) != 0);
+  assert(errno == ENOTSOCK);
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
According to the specification [1] the API should behave similarly to the POSIX one, therefore expecting specific errno codes

https://github.com/WebAssembly/WASI/blob/2980bb39e1d2a4a2adae4748908cb4325cd41a26/legacy/preview1/docs.md#sock_shutdown