### PR TITLE
export memory for the C wasi-threads test module

### DIFF
--- a/scripts/update-proposal-tests.sh
+++ b/scripts/update-proposal-tests.sh
@@ -5,7 +5,7 @@ REPOS=(
     "wasi-threads"
 )
 
-WASI_VERSION=20
+WASI_VERSION=22
 WASI_SDK_DIR=$(pwd)/wasi-sdk
 BASE_BRANCH="prod/testsuite-base"
 PROPOSALS_DIR="tests/proposals"
@@ -25,7 +25,7 @@ function install_wasi_sdk()
 
 function build_wasi-threads()
 {
-    CC="$WASI_SDK_DIR/bin/clang -pthread -Wl,--import-memory --target=wasm32-wasi-threads" ./build.sh
+    CC="$WASI_SDK_DIR/bin/clang -pthread -Wl,--import-memory -Wl,--export-memory --target=wasm32-wasi-threads" ./build.sh
 }
 
 function update_repo()


### PR DESCRIPTION
wasi requires the memory exported as "memory".
certain runtimes actually requires it. (eg. wasmtime)

cf. https://github.com/WebAssembly/wasi-sdk/pull/297

also, bump the wasi-sdk version because this doesn't work with an old wasm-ld.