### PR TITLE
Close file_fd in path_link preventing file deletion on windows

### DIFF
--- a/tests/rust/src/bin/path_link.rs
+++ b/tests/rust/src/bin/path_link.rs
@@ -94,6 +94,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
     wasi::path_unlink_file(subdir_fd, "link").expect("removing a link");
     wasi::fd_close(subdir_fd).expect("Closing subdir_fd"); // needed for Windows
     wasi::fd_close(link_fd).expect("Closing link_fd"); // needed for Windows
+    wasi::fd_close(file_fd).expect("Closing file_fd"); // needed for Windows
     wasi::path_remove_directory(dir_fd, "subdir").expect("removing a subdirectory");
 
     // Create a link to a path that already exists


### PR DESCRIPTION
Unclosed file_fd  prevents deletion of file and its directory on Windows