### PR TITLE
pwrite-with-append.c: ensure that O_APPEND is actually working

### DIFF
--- a/tests/c/testsuite/pwrite-with-append.c
+++ b/tests/c/testsuite/pwrite-with-append.c
@@ -1,31 +1,36 @@
 #include <assert.h>
-#include <stdio.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 int main() {
   char buf[4];
   int fd;
-  FILE *file;
   size_t size;
 
-  file = fopen("fs-tests.dir/pwrite.cleanup", "a+");
-  assert(file != NULL);
+  fd = open("fs-tests.dir/pwrite.cleanup",
+            O_CREAT | O_TRUNC | O_WRONLY | O_APPEND);
+  assert(fd != -1);
 
-  fd = fileno(file);
+  size = write(fd, buf, 2);
+  assert(size == 2);
 
-  size = fwrite(buf, 1, 4, file);
-  assert(size == sizeof(buf));
-  fflush(file);
+  // test if O_APPEND is working
+  assert(lseek(fd, 0, SEEK_SET) == 0);
+  size = write(fd, buf, 2);
+  assert(size == 2);
+  assert(lseek(fd, 0, SEEK_CUR) == 4);
 
-  size = pwrite(fd, buf, 4, 0);
-  assert(size == sizeof(buf));
-  fflush(file);
+  size = pwrite(fd, buf, 3, 0);
+  assert(size == 3);
 
   // fd_pwrite should write from offset 0 regardless of append.
+  // (thus shouln't extend the file.)
+  // it shouldn't move the file offset either.
+  assert(lseek(fd, 0, SEEK_CUR) == 4);
   assert(lseek(fd, 0, SEEK_END) == 4);
 
-  fclose(file);
+  close(fd);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
the old code would pass for an implementation which ignores O_APPEND.