### PR TITLE
ci: bump the version of a few actions

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
 
-      - name: Install wasm32-wasi target for Rust
-        run: rustup target add wasm32-wasi
+      - name: Install wasm32-wasip1 target for Rust
+        run: rustup target add wasm32-wasip1
 
       - name: Build tests
         working-directory: tests/rust

--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload precompiled tests
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: assemblyscript-testsuite
           path: tests/assemblyscript/testsuite
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload precompiled tests
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rust-testsuite
           path: tests/rust/testsuite
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload precompiled tests
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: c-testsuite
           path: tests/c/testsuite
@@ -150,7 +150,7 @@ jobs:
         run: git rm --ignore-unmatch tests/${{ matrix.suite }}/testsuite/*.wasm
 
       - name: Download ${{ matrix.suite }} test binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.suite }}-testsuite
           path: ./tests/${{ matrix.suite }}/testsuite

--- a/tests/rust/build.sh
+++ b/tests/rust/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ueo pipefail
 
-cargo build --target=wasm32-wasi
+cargo build --target=wasm32-wasip1
 
-cp target/wasm32-wasi/debug/*.wasm testsuite/
+cp target/wasm32-wasip1/debug/*.wasm testsuite/


### PR DESCRIPTION
cf. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

also, update rust wasi target name.