### PR TITLE
Add Windows 11 arm to ci

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
     env:
       WASI_VERSION: 17
     steps:
@@ -94,7 +94,7 @@ jobs:
         run: echo SYSTEM_NAME=macos >> $GITHUB_ENV
 
       - name: Setup WASI SDK download - Windows
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os, 'windows')
         run: echo SYSTEM_NAME=mingw >> $env:GITHUB_ENV
 
       - name: Download WASI SDK

--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     env:
       WASI_VERSION: 17
     steps:


### PR DESCRIPTION
 According to https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/ Windows arm Github runners are now available for free for public repositories. Therefore I have added them to wasi-testsuites ci.