### PR TITLE
Fix windows-arm build

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Initialize node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Install dependencies
         working-directory: tests/assemblyscript
@@ -58,7 +58,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install wasm32-wasip1 target for Rust
-        run: rustup target add wasm32-wasip1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
 
       - name: Build tests
         working-directory: tests/rust


### PR DESCRIPTION
 - Update nodejs version (version 16 wasn't available on windows-arm)
 - Switch to actions-rust-lang/setup-rust-toolchain@v1 for installing the toolchain - windows-arm by default doesn't support rustup; instead of explicitly installing it, I just used the dedicated action for that