### PR TITLE
Update to wasi-sdk 27, for test compilation

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -82,22 +82,26 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     env:
-      WASI_VERSION: 17
+      WASI_VERSION: 27
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
 
       - name: Setup WASI SDK download - Linux
         if: matrix.os == 'ubuntu-latest'
-        run: echo SYSTEM_NAME=linux >> $GITHUB_ENV
+        run: echo SYSTEM_NAME=x86_64-linux >> $GITHUB_ENV
 
       - name: Setup WASI SDK download - MacOS
         if: matrix.os == 'macos-latest'
-        run: echo SYSTEM_NAME=macos >> $GITHUB_ENV
+        run: echo SYSTEM_NAME=arm64-macos >> $GITHUB_ENV
 
-      - name: Setup WASI SDK download - Windows
-        if: startsWith(matrix.os, 'windows')
-        run: echo SYSTEM_NAME=mingw >> $env:GITHUB_ENV
+      - name: Setup WASI SDK download - Windows (x86)
+        if: matrix.os == 'windows-latest'
+        run: echo SYSTEM_NAME=x86_64-windows >> $env:GITHUB_ENV
+
+      - name: Setup WASI SDK download - Windows (ARM)
+        if: matrix.os == 'windows-11-arm'
+        run: echo SYSTEM_NAME=arm64-windows >> $env:GITHUB_ENV
 
       - name: Download WASI SDK
         working-directory: tests/c
@@ -112,12 +116,12 @@ jobs:
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'
         working-directory: tests/c
-        run: find testsuite -regex '.*\.\(c\|h\)' -print0 | xargs -0 -n1 ./wasi-sdk-${WASI_VERSION}.0/bin/clang-format --style=file --dry-run -Werror
+        run: find testsuite -regex '.*\.\(c\|h\)' -print0 | xargs -0 -n1 ./wasi-sdk-${WASI_VERSION}.0-${SYSTEM_NAME}/bin/clang-format --style=file --dry-run -Werror
 
       - name: Build tests
         shell: bash
         working-directory: tests/c
-        run: CC="./wasi-sdk-${WASI_VERSION}.0/bin/clang" ./build.sh
+        run: CC="./wasi-sdk-${WASI_VERSION}.0-${SYSTEM_NAME}/bin/clang" ./build.sh
 
       - name: Upload precompiled tests
         if: matrix.os == 'ubuntu-latest'

--- a/tests/c/build.sh
+++ b/tests/c/build.sh
@@ -8,6 +8,6 @@ for input in testsuite/*.c; do
 
   if [ "$input" -nt "$output" ]; then
     echo "Compiling $input"
-    $CC "$input" -o "$output"
+    $CC --target=wasm32-wasip1 "$input" -o "$output"
   fi
 done

--- a/tests/c/testsuite/fopen-with-no-access.c
+++ b/tests/c/testsuite/fopen-with-no-access.c
@@ -7,7 +7,7 @@ int main() {
   FILE *file = fopen("fs-tests.dir/file", "r");
 
   assert(file == NULL);
-  assert(errno == ENOTCAPABLE);
+  assert(errno == ENOTCAPABLE || errno == ENOENT);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Also, pass --target=wasm32-wasip1 to build.sh, given that the existing tests target that version.