### PR TITLE
Use a higher fd in sock_shutdown-invalid_fd.c

### DIFF
--- a/tests/c/testsuite/sock_shutdown-invalid_fd.c
+++ b/tests/c/testsuite/sock_shutdown-invalid_fd.c
@@ -5,7 +5,7 @@
 #include <sys/socket.h>
 
 int main() {
-  int fd = 3;
+  int fd = 420;
   assert(shutdown(fd, SHUT_RD) != 0);
   assert(errno == EBADF);
 


### PR DESCRIPTION
By my understanding fds starting from 3 refer to preopened directories.
Thus accessing fd 3 will cause an ENOTSOCK and fail the test.
Using a higher fd solves this issue.

If there's any problem with this PR please let me know.