### PR TITLE
Rework fd_allocate, file_allocate tests to allow for ENOTSUP at run time

### DIFF
--- a/tests/rust/src/bin/file_allocate.rs
+++ b/tests/rust/src/bin/file_allocate.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory, TESTCONFIG};
+use wasi_tests::{create_tmp_dir, open_scratch_directory};
 
 unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -25,21 +25,22 @@ unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
     let mut stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
     assert_eq!(stat.size, 0, "file size should be 0");
 
-    if TESTCONFIG.support_fd_allocate() {
-        // Allocate some size
-        wasi::fd_allocate(file_fd, 0, 100).expect("allocating size");
-        stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
-        assert_eq!(stat.size, 100, "file size should be 100");
+    match wasi::fd_allocate(file_fd, 0, 100) {
+        Ok(()) => {
+            stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+            assert_eq!(stat.size, 100, "file size should be 100");
 
-        // Allocate should not modify if less than current size
-        wasi::fd_allocate(file_fd, 10, 10).expect("allocating size less than current size");
-        stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
-        assert_eq!(stat.size, 100, "file size should remain unchanged at 100");
+            // Allocate should not modify if less than current size
+            wasi::fd_allocate(file_fd, 10, 10).expect("allocating size less than current size");
+            stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+            assert_eq!(stat.size, 100, "file size should remain unchanged at 100");
 
-        // Allocate should modify if offset+len > current_len
-        wasi::fd_allocate(file_fd, 90, 20).expect("allocating size larger than current size");
-        stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
-        assert_eq!(stat.size, 110, "file size should increase from 100 to 110");
+            // Allocate should modify if offset+len > current_len
+            wasi::fd_allocate(file_fd, 90, 20).expect("allocating size larger than current size");
+            stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+            assert_eq!(stat.size, 110, "file size should increase from 100 to 110");
+        },
+        Err(err) => { assert_eq!(err, wasi::ERRNO_NOTSUP, "allocating size"); }
     }
     wasi::fd_close(file_fd).expect("closing a file");
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");

--- a/tests/rust/src/config.rs
+++ b/tests/rust/src/config.rs
@@ -1,7 +1,6 @@
 pub struct TestConfig {
     errno_mode: ErrnoMode,
     no_dangling_filesystem: bool,
-    no_fd_allocate: bool,
     no_rename_dir_to_empty_dir: bool,
     no_fdflags_sync_support: bool,
 }
@@ -25,14 +24,12 @@ impl TestConfig {
             ErrnoMode::Permissive
         };
         let no_dangling_filesystem = std::env::var("NO_DANGLING_FILESYSTEM").is_ok();
-        let no_fd_allocate = std::env::var("NO_FD_ALLOCATE").is_ok();
         let no_rename_dir_to_empty_dir = std::env::var("NO_RENAME_DIR_TO_EMPTY_DIR").is_ok();
         let no_fdflags_sync_support = std::env::var("NO_FDFLAGS_SYNC_SUPPORT").is_ok();
 
         TestConfig {
             errno_mode,
             no_dangling_filesystem,
-            no_fd_allocate,
             no_rename_dir_to_empty_dir,
             no_fdflags_sync_support,
         }
@@ -57,9 +54,6 @@ impl TestConfig {
     }
     pub fn support_dangling_filesystem(&self) -> bool {
         !self.no_dangling_filesystem
-    }
-    pub fn support_fd_allocate(&self) -> bool {
-        !self.no_fd_allocate
     }
     pub fn support_rename_dir_to_empty_dir(&self) -> bool {
         !self.no_rename_dir_to_empty_dir


### PR DESCRIPTION
The TESTCONFIG machinery is not used by the test runner: there is no facility to pass --env arguments to the adapters.