### PR TITLE
path_filestat: Dynamically allow fdflags_sync to fail

### DIFF
--- a/tests/rust/src/config.rs
+++ b/tests/rust/src/config.rs
@@ -3,7 +3,6 @@ pub struct TestConfig {
     no_dangling_filesystem: bool,
     no_fd_allocate: bool,
     no_rename_dir_to_empty_dir: bool,
-    no_fdflags_sync_support: bool,
 }
 
 enum ErrnoMode {
@@ -27,14 +26,12 @@ impl TestConfig {
         let no_dangling_filesystem = std::env::var("NO_DANGLING_FILESYSTEM").is_ok();
         let no_fd_allocate = std::env::var("NO_FD_ALLOCATE").is_ok();
         let no_rename_dir_to_empty_dir = std::env::var("NO_RENAME_DIR_TO_EMPTY_DIR").is_ok();
-        let no_fdflags_sync_support = std::env::var("NO_FDFLAGS_SYNC_SUPPORT").is_ok();
 
         TestConfig {
             errno_mode,
             no_dangling_filesystem,
             no_fd_allocate,
             no_rename_dir_to_empty_dir,
-            no_fdflags_sync_support,
         }
     }
     pub fn errno_expect_unix(&self) -> bool {
@@ -63,8 +60,5 @@ impl TestConfig {
     }
     pub fn support_rename_dir_to_empty_dir(&self) -> bool {
         !self.no_rename_dir_to_empty_dir
-    }
-    pub fn support_fdflags_sync(&self) -> bool {
-        !self.no_fdflags_sync_support
     }
 }


### PR DESCRIPTION
Instead of using the TESTCONFIG infra, just try to open with the sync flag; fall back if it's not supported.