### PR TITLE
Fix compile-tests workflow

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -140,7 +140,13 @@ jobs:
         uses: ./.github/actions/git-config
 
       - name: Merge main branch changes
-        run: git merge ${{ github.sha }}
+        run: |
+          git merge --no-commit -Sours ${{ github.sha }}
+          git checkout ${{ github.sha }} .
+          git checkout HEAD tests/assemblyscript/testsuite
+          git checkout HEAD tests/c/testsuite
+          git checkout HEAD tests/rust/testsuite
+          git commit -m "Merge commit ${{ github.sha }} into prod/testsuite-base"
 
       - name: Remove existing binaries
         run: rm -rf tests/${{ matrix.suite }}/testsuite


### PR DESCRIPTION
Moving source files out of the built dir effectively removed the built dir, causing merge conflicts in the workflow that rebuilt the wasm tests which were supposed to be in that dir.

Fix by doing a `--strategy ours` merge, then forcibly resetting the tree state to the main branch, then checking out the built files.  This ensures that the tree contains precisely the upstream source code, plus our built files, while keeping the parent tree.