### PR TITLE
Disable some tests if rights aren't supported

### DIFF
--- a/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
@@ -1,11 +1,17 @@
 use std::{env, process};
 use wasi_tests::{
     assert_errno, create_tmp_dir, drop_rights, fd_get_rights, open_scratch_directory,
+    supports_rights,
 };
 
 const TEST_FILENAME: &'static str = "file.cleanup";
 
 unsafe fn test_fd_fdstat_set_rights(dir_fd: wasi::Fd) {
+    // For hosts that don't support rights at all skip this test.
+    if !supports_rights(dir_fd) {
+        return;
+    }
+
     let fd = wasi::path_open(
         dir_fd,
         0,

--- a/tests/rust/wasm32-wasip1/src/lib.rs
+++ b/tests/rust/wasm32-wasip1/src/lib.rs
@@ -175,3 +175,11 @@ macro_rules! assert_errno {
         }
     };
 }
+
+pub unsafe fn supports_rights(fd: wasi::Fd) -> bool {
+    let fd_stat = wasi::fd_fdstat_get(fd).expect("fd_fdstat_get failed");
+    match wasi::fd_fdstat_set_rights(fd, fd_stat.fs_rights_base, fd_stat.fs_rights_inheriting) {
+        Err(wasi::ERRNO_NOTSUP) => false,
+        _ => true,
+    }
+}


### PR DESCRIPTION
Disable the `fd_fdstat_set_rights` tests entirely if rights aren't supported by the host and skip some checks in `path_link` if rights aren't supported. This gets these tests passing locally for Wasmtime, for example.