### PR TITLE
rust build: copying dirs copies symlinks

### DIFF
--- a/tests/rust/build.py
+++ b/tests/rust/build.py
@@ -69,7 +69,8 @@ def cp_R(src, dst):
     if args.verbose:
         print(f"cp -R {src} {dst}")
     if not args.dry_run:
-        shutil.copytree(src, dst, dirs_exist_ok=True)
+        shutil.copytree(src, dst, symlinks=True, ignore_dangling_symlinks=True,
+                        dirs_exist_ok=True)
 
 def write_manifest(path, manifest):
     if args.verbose:


### PR DESCRIPTION
* tests/rust/build.py (cp_R): Add appropriate flags to copytree.