### PR TITLE
Move support_rights to be a config option

### DIFF
--- a/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
@@ -1,14 +1,13 @@
 use std::{env, process};
 use wasi_tests::{
-    assert_errno, create_tmp_dir, drop_rights, fd_get_rights, open_scratch_directory,
-    supports_rights,
+    assert_errno, create_tmp_dir, drop_rights, fd_get_rights, open_scratch_directory, TESTCONFIG,
 };
 
 const TEST_FILENAME: &'static str = "file.cleanup";
 
 unsafe fn test_fd_fdstat_set_rights(dir_fd: wasi::Fd) {
     // For hosts that don't support rights at all skip this test.
-    if !supports_rights(dir_fd) {
+    if !TESTCONFIG.support_filesystem_rights() {
         return;
     }
 

--- a/tests/rust/wasm32-wasip1/src/bin/path_link.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_link.rs
@@ -1,6 +1,6 @@
 use std::{env, process};
 use wasi_tests::{
-    assert_errno, create_file, create_tmp_dir, open_scratch_directory, supports_rights, TESTCONFIG,
+    assert_errno, create_file, create_tmp_dir, open_scratch_directory, TESTCONFIG,
 };
 
 const TEST_RIGHTS: wasi::Rights = wasi::RIGHTS_FD_READ
@@ -45,7 +45,7 @@ fn filestats_assert_eq(left: wasi::Filestat, right: wasi::Filestat) {
 
 // This is temporary until `wasi` implements `Debug` and `PartialEq` for
 // `wasi::Fdstat`.
-fn fdstats_assert_eq(left: wasi::Fdstat, right: wasi::Fdstat, supports_rights: bool) {
+fn fdstats_assert_eq(left: wasi::Fdstat, right: wasi::Fdstat) {
     assert_eq!(left.fs_flags, right.fs_flags, "fs_flags should be equal");
     assert_eq!(
         left.fs_filetype, right.fs_filetype,
@@ -53,7 +53,7 @@ fn fdstats_assert_eq(left: wasi::Fdstat, right: wasi::Fdstat, supports_rights: b
     );
 
     // Only tests rights if the host in general supports rights.
-    if supports_rights {
+    if TESTCONFIG.support_filesystem_rights() {
         assert_eq!(
             left.fs_rights_base, right.fs_rights_base,
             "fs_rights_base should be equal"
@@ -74,7 +74,7 @@ unsafe fn check_rights(orig_fd: wasi::Fd, link_fd: wasi::Fd) {
     // Compare Fdstats
     let orig_fdstat = wasi::fd_fdstat_get(orig_fd).expect("reading fdstat of the source");
     let link_fdstat = wasi::fd_fdstat_get(link_fd).expect("reading fdstat of the link");
-    fdstats_assert_eq(orig_fdstat, link_fdstat, supports_rights(orig_fd));
+    fdstats_assert_eq(orig_fdstat, link_fdstat);
 }
 
 // Extra calls of fd_close are needed for Windows, which will not remove

--- a/tests/rust/wasm32-wasip1/src/config.rs
+++ b/tests/rust/wasm32-wasip1/src/config.rs
@@ -2,6 +2,7 @@ pub struct TestConfig {
     errno_mode: ErrnoMode,
     no_dangling_filesystem: bool,
     no_rename_dir_to_empty_dir: bool,
+    no_filesystem_rights: bool,
 }
 
 enum ErrnoMode {
@@ -24,11 +25,13 @@ impl TestConfig {
         };
         let no_dangling_filesystem = std::env::var("NO_DANGLING_FILESYSTEM").is_ok();
         let no_rename_dir_to_empty_dir = std::env::var("NO_RENAME_DIR_TO_EMPTY_DIR").is_ok();
+        let no_filesystem_rights = std::env::var("NO_FILESYSTEM_RIGHTS").is_ok();
 
         TestConfig {
             errno_mode,
             no_dangling_filesystem,
             no_rename_dir_to_empty_dir,
+            no_filesystem_rights,
         }
     }
     pub fn errno_expect_unix(&self) -> bool {
@@ -54,5 +57,8 @@ impl TestConfig {
     }
     pub fn support_rename_dir_to_empty_dir(&self) -> bool {
         !self.no_rename_dir_to_empty_dir
+    }
+    pub fn support_filesystem_rights(&self) -> bool {
+        !self.no_filesystem_rights
     }
 }

--- a/tests/rust/wasm32-wasip1/src/lib.rs
+++ b/tests/rust/wasm32-wasip1/src/lib.rs
@@ -175,11 +175,3 @@ macro_rules! assert_errno {
         }
     };
 }
-
-pub unsafe fn supports_rights(fd: wasi::Fd) -> bool {
-    let fd_stat = wasi::fd_fdstat_get(fd).expect("fd_fdstat_get failed");
-    match wasi::fd_fdstat_set_rights(fd, fd_stat.fs_rights_base, fd_stat.fs_rights_inheriting) {
-        Err(wasi::ERRNO_NOTSUP) => false,
-        _ => true,
-    }
-}


### PR DESCRIPTION
Since you re-started updating the "release branches", in Chicory we picked up this change: https://github.com/WebAssembly/wasi-testsuite/commit/92c0545ae4044ea6ed370589e4007ac769e182ec

That breaks the integration tests in Chicory since `fd_fdstat_set_rights` is fully not implemented and throws an exception.
If I understand this repository correctly(it was not me doing the initial integration, catching up now), a "runtime agnostic" of disabling tests needs to go through the `TESTCONFIG`.

Fixes: https://github.com/dylibso/chicory/issues/1042