### PR TITLE
Skip tests that runtimes don't support

### DIFF
--- a/adapters/pywasm.py
+++ b/adapters/pywasm.py
@@ -21,10 +21,14 @@ def get_version() -> str:
     return output[1]
 
 
+def get_wasi_versions() -> List[str]:
+    return ["wasm32-wasip1"]
+
 def compute_argv(test_path: str,
                  args: List[str],
                  env: Dict[str, str],
-                 dirs: List[Tuple[Path, str]]) -> List[str]:
+                 dirs: List[Tuple[Path, str]],
+                 wasi_version: str) -> List[str]:
     argv = [str(RUN_PYWASM)]
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]

--- a/adapters/wasm-micro-runtime.py
+++ b/adapters/wasm-micro-runtime.py
@@ -21,10 +21,15 @@ def get_version() -> str:
     return output[1]
 
 
+def get_wasi_versions() -> List[str]:
+    return ["wasm32-wasip1"]
+
+
 def compute_argv(test_path: str,
                  args: List[str],
                  env: Dict[str, str],
-                 dirs: List[Tuple[Path, str]]) -> List[str]:
+                 dirs: List[Tuple[Path, str]],
+                 wasi_version: str) -> List[str]:
     argv = [] + IWASM
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]

--- a/adapters/wasmedge.py
+++ b/adapters/wasmedge.py
@@ -21,10 +21,15 @@ def get_version() -> str:
     return output[1]
 
 
+def get_wasi_versions() -> List[str]:
+    return ["wasm32-wasip1"]
+
+
 def compute_argv(test_path: str,
                  args: List[str],
                  env: Dict[str, str],
-                 dirs: List[Tuple[Path, str]]) -> List[str]:
+                 dirs: List[Tuple[Path, str]],
+                 wasi_version: str) -> List[str]:
     argv = [] + WASMEDGE
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]

--- a/adapters/wasmtime.py
+++ b/adapters/wasmtime.py
@@ -21,10 +21,15 @@ def get_version() -> str:
     return output[1]
 
 
+def get_wasi_versions() -> List[str]:
+    return ["wasm32-wasip1", "wasm32-wasip3"]
+
+
 def compute_argv(test_path: str,
                  args: List[str],
                  env: Dict[str, str],
-                 dirs: List[Tuple[Path, str]]) -> List[str]:
+                 dirs: List[Tuple[Path, str]],
+                 wasi_version: str) -> List[str]:
     argv = [] + WASMTIME
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]

--- a/adapters/wazero.py
+++ b/adapters/wazero.py
@@ -23,10 +23,15 @@ def get_version() -> str:
     return version
 
 
+def get_wasi_versions() -> List[str]:
+    return ["wasm32-wasip1"]
+
+
 def compute_argv(test_path: str,
                  args: List[str],
                  env: Dict[str, str],
-                 dirs: List[Tuple[Path, str]]) -> List[str]:
+                 dirs: List[Tuple[Path, str]],
+                 wasi_version: str) -> List[str]:
     argv = WAZERO + ["run", "-hostlogging=filesystem"]
     for k, v in env.items():
         argv += [f"-env={k}={v}"]

--- a/adapters/wizard.py
+++ b/adapters/wizard.py
@@ -29,10 +29,15 @@ def get_version() -> str:
     return output[1]
 
 
+def get_wasi_versions() -> List[str]:
+    return ["wasm32-wasip1"]
+
+
 def compute_argv(test_path: str,
                  args: List[str],
                  env: Dict[str, str],
-                 dirs: List[Tuple[Path, str]]) -> List[str]:
+                 dirs: List[Tuple[Path, str]],
+                 wasi_version: str) -> List[str]:
     argv = [] + WIZARD
     for k, v in env.items():
         argv += [f"--env={k}={v}"]

--- a/run-tests
+++ b/run-tests
@@ -57,7 +57,7 @@ def find_runtime_adapters(root, verbose=False):
     for candidate in root.glob("*.py"):
         try:
             adapter = runtime_adapter.RuntimeAdapter(candidate)
-            print(f"  {candidate.name}: {adapter.get_version()}")
+            print(f"  {candidate.name}: {adapter.get_meta()}")
             adapters.append(adapter)
         except runtime_adapter.LegacyRuntimeAdapterError:
             print(f"  {candidate} is too old; update to new module format.")
@@ -85,9 +85,7 @@ if options.runtime_adapter:
 else:
     runtime_adapters = find_runtime_adapters(Path(__file__).parent / "adapters")
 
-exclude_filters = [JSONTestExcludeFilter(filt) for filt in options.exclude_filter]
-
 sys.exit(run_tests(runtime_adapters, test_suite,
                    color=not options.disable_colors,
                    json_log_file=options.json_output_location,
-                   exclude_filters=exclude_filters))
+                   exclude_filters=options.exclude_filter))

--- a/test-runner/tests/test_test_suite.py
+++ b/test-runner/tests/test_test_suite.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import wasi_test_runner.test_case as tc
 import wasi_test_runner.test_suite as ts
-from wasi_test_runner.runtime_adapter import RuntimeVersion
+from wasi_test_runner.runtime_adapter import RuntimeMeta
 
 
 def create_test_case(name: str, is_executed: bool, is_failed: bool) -> tc.TestCase:
@@ -18,8 +18,10 @@ def create_test_case(name: str, is_executed: bool, is_failed: bool) -> tc.TestCa
 
 def test_test_suite_should_return_correct_count() -> None:
     suite = ts.TestSuite(
-        "suite",
-        RuntimeVersion("test-runtime", "3.14"),
+        ts.TestSuiteMeta("suite",
+                         tc.WasiVersion.WASM32_WASIP1,
+                         RuntimeMeta("test-runtime", "3.14",
+                                     frozenset([tc.WasiVersion.WASM32_WASIP1]))),
         10.0,
         datetime.now(),
         [

--- a/test-runner/wasi_test_runner/__main__.py
+++ b/test-runner/wasi_test_runner/__main__.py
@@ -6,7 +6,7 @@ from typing import List
 from .runtime_adapter import RuntimeAdapter
 from .harness import run_all_tests
 from .filters import TestFilter
-from .filters import JSONTestExcludeFilter
+from .filters import JSONTestExcludeFilter, UnsupportedWasiTestExcludeFilter
 from .reporters import TestReporter
 from .reporters.console import ConsoleTestReporter
 from .reporters.json import JSONTestReporter
@@ -56,7 +56,7 @@ def main() -> int:
 
     validators: List[Validator] = [exit_code_validator, stdout_validator]
 
-    filters: List[TestFilter] = []
+    filters: List[TestFilter] = [UnsupportedWasiTestExcludeFilter()]
     for filt in options.exclude_filter:
         filters.append(JSONTestExcludeFilter(filt))
 

--- a/test-runner/wasi_test_runner/filters.py
+++ b/test-runner/wasi_test_runner/filters.py
@@ -4,15 +4,24 @@ from abc import abstractmethod
 
 import json
 
-from .runtime_adapter import RuntimeVersion
+from .test_suite import TestSuiteMeta
 
 
 class TestFilter(ABC):
     @abstractmethod
     def should_skip(
-        self, runtime: RuntimeVersion, test_suite_name: str, test_name: str
+        self, meta: TestSuiteMeta, test_name: str
     ) -> Union[Tuple[Literal[True], str], Tuple[Literal[False], Literal[None]]]:
         pass
+
+
+class UnsupportedWasiTestExcludeFilter(TestFilter):
+    def should_skip(
+        self, meta: TestSuiteMeta, test_name: str
+    ) -> Union[Tuple[Literal[True], str], Tuple[Literal[False], Literal[None]]]:
+        if meta.wasi_version not in meta.runtime.supported_wasi_versions:
+            return True, "WASI version unsupported by runtime"
+        return False, None
 
 
 class JSONTestExcludeFilter(TestFilter):
@@ -21,9 +30,9 @@ class JSONTestExcludeFilter(TestFilter):
             self.filter_dict = json.load(file)
 
     def should_skip(
-        self, runtime: RuntimeVersion, test_suite_name: str, test_name: str
+        self, meta: TestSuiteMeta, test_name: str
     ) -> Union[Tuple[Literal[True], str], Tuple[Literal[False], Literal[None]]]:
-        test_suite_filter = self.filter_dict.get(test_suite_name)
+        test_suite_filter = self.filter_dict.get(meta.name)
         if test_suite_filter is None:
             return False, None
         why = test_suite_filter.get(test_name)

--- a/test-runner/wasi_test_runner/harness.py
+++ b/test-runner/wasi_test_runner/harness.py
@@ -1,7 +1,9 @@
 from typing import List
 from pathlib import Path
 
-from .filters import TestFilter, JSONTestExcludeFilter
+from .filters import (
+    TestFilter, JSONTestExcludeFilter, UnsupportedWasiTestExcludeFilter
+)
 from .reporters import TestReporter
 from .reporters.console import ConsoleTestReporter
 from .reporters.json import JSONTestReporter
@@ -19,9 +21,9 @@ def run_tests(runtimes: List[RuntimeAdapter],
     reporters: List[TestReporter] = [ConsoleTestReporter(color)]
     if json_log_file:
         reporters.append(JSONTestReporter(json_log_file))
-    filters: List[TestFilter] = []
+    filters: List[TestFilter] = [UnsupportedWasiTestExcludeFilter()]
     if exclude_filters is not None:
-        filters = [JSONTestExcludeFilter(str(filt)) for filt in exclude_filters]
+        filters += [JSONTestExcludeFilter(str(filt)) for filt in exclude_filters]
 
     return run_all_tests(runtimes, [str(p) for p in test_suite_paths],
                          validators, reporters, filters)

--- a/test-runner/wasi_test_runner/reporters/__init__.py
+++ b/test-runner/wasi_test_runner/reporters/__init__.py
@@ -1,13 +1,11 @@
 from abc import ABC
 
 from ..test_case import TestCase
-from ..test_suite import TestSuite
-from ..runtime_adapter import RuntimeVersion
+from ..test_suite import TestSuite, TestSuiteMeta
 
 
 class TestReporter(ABC):
-    def report_test(self, test_suite_name: str, runtime: RuntimeVersion,
-                    test: TestCase) -> None:
+    def report_test(self, meta: TestSuiteMeta, test: TestCase) -> None:
         pass
 
     def report_test_suite(self, test_suite: TestSuite) -> None:

--- a/test-runner/wasi_test_runner/reporters/console.py
+++ b/test-runner/wasi_test_runner/reporters/console.py
@@ -4,8 +4,8 @@ from colorama import Fore, init
 
 from . import TestReporter
 from ..test_case import TestCase
-from ..test_suite import TestSuite
-from ..runtime_adapter import RuntimeVersion
+from ..test_suite import TestSuite, TestSuiteMeta
+from ..runtime_adapter import RuntimeMeta
 
 
 class ConsoleTestReporter(TestReporter):
@@ -18,15 +18,14 @@ class ConsoleTestReporter(TestReporter):
         super().__init__()
         init(autoreset=True)
         self._test_suites: List[TestSuite] = []
-        self._current_test_suite: Optional[str] = None
+        self._current_test_suite: Optional[TestSuiteMeta] = None
         self._colored = colored
         self._verbose = verbose
 
-    def report_test(self, test_suite_name: str, runtime: RuntimeVersion,
-                    test: TestCase) -> None:
+    def report_test(self, meta: TestSuiteMeta, test: TestCase) -> None:
         if self._current_test_suite is None:
-            print(f"Running test suite {test_suite_name} with {runtime}")
-            self._current_test_suite = test_suite_name
+            print(f"Running test suite {meta.name} with {meta.runtime}")
+            self._current_test_suite = meta
 
         if self._verbose:
             self._report_test_verbose(test)
@@ -63,16 +62,16 @@ class ConsoleTestReporter(TestReporter):
     def finalize(self) -> None:
         print("===== Test results =====")
 
-        test_suites_by_runtime: Dict[RuntimeVersion, List[TestSuite]] = {}
+        test_suites_by_runtime: Dict[RuntimeMeta, List[TestSuite]] = {}
         for suite in self._test_suites:
-            if suite.runtime not in test_suites_by_runtime:
-                test_suites_by_runtime[suite.runtime] = []
-            test_suites_by_runtime[suite.runtime].append(suite)
+            if suite.meta.runtime not in test_suites_by_runtime:
+                test_suites_by_runtime[suite.meta.runtime] = []
+            test_suites_by_runtime[suite.meta.runtime].append(suite)
 
         for runtime, test_suites in test_suites_by_runtime.items():
             self._print_result_for_runtime(runtime, test_suites)
 
-    def _print_result_for_runtime(self, runtime: RuntimeVersion,
+    def _print_result_for_runtime(self, runtime: RuntimeMeta,
                                   suites: List[TestSuite]) -> None:
         total_skip = total_pass = total_fail = 0
 

--- a/test-runner/wasi_test_runner/reporters/json.py
+++ b/test-runner/wasi_test_runner/reporters/json.py
@@ -23,10 +23,10 @@ class JSONTestReporter(TestReporter):
         for suite in self._test_suites:
             results.append(
                 {
-                    "name": suite.name,
+                    "name": suite.meta.name,
                     "runtime": {
-                        "name": suite.runtime.name,
-                        "version": suite.runtime.version
+                        "name": suite.meta.runtime.name,
+                        "version": suite.meta.runtime.version
                     },
                     "duration_s": suite.duration_s,
                     "failed": suite.fail_count,

--- a/test-runner/wasi_test_runner/test_case.py
+++ b/test-runner/wasi_test_runner/test_case.py
@@ -1,6 +1,13 @@
 import logging
 import json
+from enum import StrEnum
 from typing import List, NamedTuple, TypeVar, Type, Dict, Any, Optional
+
+
+class WasiVersion(StrEnum):
+    WASM32_WASIP1 = 'wasm32-wasip1'
+    WASM32_WASIP2 = 'wasm32-wasip2'
+    WASM32_WASIP3 = 'wasm32-wasip3'
 
 
 class Output(NamedTuple):

--- a/test-runner/wasi_test_runner/test_suite.py
+++ b/test-runner/wasi_test_runner/test_suite.py
@@ -1,12 +1,17 @@
 from typing import NamedTuple, List
 from datetime import datetime
-from .test_case import TestCase
-from .runtime_adapter import RuntimeVersion
+from .test_case import TestCase, WasiVersion
+from .runtime_adapter import RuntimeMeta
+
+
+class TestSuiteMeta(NamedTuple):
+    name: str
+    wasi_version: WasiVersion
+    runtime: RuntimeMeta
 
 
 class TestSuite(NamedTuple):
-    name: str
-    runtime: RuntimeVersion
+    meta: TestSuiteMeta
     duration_s: float
     time: datetime
     test_cases: List[TestCase]

--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -7,7 +7,7 @@ import time
 
 from datetime import datetime
 from pathlib import Path
-from typing import List, cast, Tuple
+from typing import List, Tuple, NamedTuple
 
 from .filters import TestFilter
 from .runtime_adapter import RuntimeAdapter
@@ -16,10 +16,16 @@ from .test_case import (
     Config,
     Output,
     TestCase,
+    WasiVersion
 )
 from .reporters import TestReporter
-from .test_suite import TestSuite
+from .test_suite import TestSuite, TestSuiteMeta
 from .validators import Validator
+
+
+class Manifest(NamedTuple):
+    name: str
+    wasi_version: WasiVersion
 
 
 # pylint: disable-msg=too-many-locals
@@ -33,30 +39,30 @@ def run_tests_from_test_suite(
     test_cases: List[TestCase] = []
     test_start = datetime.now()
 
-    test_suite_name = _read_manifest(test_suite_path)
-    runtime_version = runtime.get_version()
+    manifest = _read_manifest(Path(test_suite_path))
+    meta = TestSuiteMeta(manifest.name, manifest.wasi_version,
+                         runtime.get_meta())
 
     for test_path in glob.glob(os.path.join(test_suite_path, "*.wasm")):
         test_name = os.path.splitext(os.path.basename(test_path))[0]
         for filt in filters:
             # for now, just drop the skip reason string. it might be
             # useful to make reporters report it.
-            skip, _ = filt.should_skip(runtime_version, test_suite_name,
-                                       test_name)
+            skip, _ = filt.should_skip(meta, test_name)
             if skip:
-                test_case = _skip_single_test(runtime, validators, test_path)
+                test_case = _skip_single_test(runtime, meta, test_path)
                 break
         else:
-            test_case = _execute_single_test(runtime, validators, test_path)
+            test_case = _execute_single_test(runtime, meta, validators,
+                                             test_path)
         test_cases.append(test_case)
         for reporter in reporters:
-            reporter.report_test(test_suite_name, runtime_version, test_case)
+            reporter.report_test(meta, test_case)
 
     elapsed = (datetime.now() - test_start).total_seconds()
 
     return TestSuite(
-        name=test_suite_name,
-        runtime=runtime.get_version(),
+        meta=meta,
         time=test_start,
         duration_s=elapsed,
         test_cases=test_cases,
@@ -64,9 +70,10 @@ def run_tests_from_test_suite(
 
 
 def _skip_single_test(
-    runtime: RuntimeAdapter, _validators: List[Validator], test_path: str
+    runtime: RuntimeAdapter, meta: TestSuiteMeta, test_path: str
 ) -> TestCase:
-    config, _dir_pairs, argv = _prepare_test(runtime, test_path)
+    config, _dir_pairs, argv = _prepare_test(runtime, meta.wasi_version,
+                                             test_path)
     return TestCase(
         name=os.path.splitext(os.path.basename(test_path))[0],
         argv=argv,
@@ -77,9 +84,11 @@ def _skip_single_test(
 
 
 def _execute_single_test(
-    runtime: RuntimeAdapter, validators: List[Validator], test_path: str
+    runtime: RuntimeAdapter, meta: TestSuiteMeta, validators: List[Validator],
+    test_path: str
 ) -> TestCase:
-    config, dir_pairs, argv = _prepare_test(runtime, test_path)
+    config, dir_pairs, argv = _prepare_test(runtime, meta.wasi_version,
+                                            test_path)
     _cleanup_test_output(dir_pairs)
     test_start = time.time()
     test_output = runtime.run_test(argv)
@@ -96,11 +105,12 @@ def _execute_single_test(
 
 
 def _prepare_test(
-    runtime: RuntimeAdapter, test_path: str
+    runtime: RuntimeAdapter, wasi_version: WasiVersion, test_path: str
 ) -> Tuple[Config, List[Tuple[Path, str]], List[str]]:
     config = _read_test_config(test_path)
     dir_pairs = [(Path(test_path).parent / d, d) for d in config.dirs]
-    argv = runtime.compute_argv(test_path, config.args, config.env, dir_pairs)
+    argv = runtime.compute_argv(test_path, config.args, config.env, dir_pairs,
+                                wasi_version)
     return config, dir_pairs, argv
 
 
@@ -121,12 +131,31 @@ def _read_test_config(test_path: str) -> Config:
     return Config()
 
 
-def _read_manifest(test_suite_path: str) -> str:
-    manifest_path = os.path.join(test_suite_path, "manifest.json")
-    if not os.path.exists(manifest_path):
-        return test_suite_path
-    with open(manifest_path, encoding="utf-8") as file:
-        return cast(str, json.load(file)["name"])
+def _read_manifest(test_suite_path: Path) -> Manifest:
+    manifest_path = test_suite_path / "manifest.json"
+    if test_suite_path.name in WasiVersion:
+        name = str(test_suite_path.parent)
+        wasi_version = WasiVersion(test_suite_path.name)
+    else:
+        name = str(test_suite_path)
+        wasi_version = WasiVersion.WASM32_WASIP1
+
+    if manifest_path.exists():
+        with open(str(manifest_path), encoding="utf-8") as file:
+            contents = json.load(file)
+            assert isinstance(contents, dict)
+            for k, v in contents.items():
+                match k:
+                    case "name":
+                        assert isinstance(v, str)
+                        name = v
+                    case "version":
+                        assert v in WasiVersion
+                        wasi_version = WasiVersion[v]
+                    case _:
+                        raise RuntimeError(f"unexpected manifest option: {k}={v}")
+
+    return Manifest(name=name, wasi_version=wasi_version)
 
 
 def _cleanup_test_output(dirs: List[Tuple[Path, str]]) -> None:


### PR DESCRIPTION
Refactor to make runtime adapters declare the WASI versions they support, and for test suites to declare the WASI version they are.  By default, skip tests whose WASI version is not supported by the current run-time.

This results in a run-tests output that looks like this:
```
[dev-env] wingo@beastie ~/src/wasip3/wasi-testsuite$ WASMEDGE=../WasmEdge/build/tools/wasmedge/wasmedge WAZERO=../wazero/wazero IWASM=../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 WASMTIME="../wasmtime/target/release/wasmtime -Wcomponent-model-async=y -Sp3=y" ./run-tests
Detecting WASI runtime availability:
  wasmtime.py: wasmtime 38.0.0
  pywasm.py: pywasm 2.2.0
  wasm-micro-runtime.py: wamr 2.4.1
  wizard.py unavailable; pass `--runtime /home/wingo/src/wasip3/wasi-testsuite/adapters/wizard.py` to debug.
  wazero.py: wazero 0.0.0
  wasmedge.py: wasmedge version

Running test suite WASI C tests [wasm32-wasip1] with wasmtime 38.0.0
..............
Running test suite WASI C tests [wasm32-wasip1] with pywasm 2.2.0
!.!.!.........
Running test suite WASI C tests [wasm32-wasip1] with wamr 2.4.1
!!!.!......!!!
Running test suite WASI C tests [wasm32-wasip1] with wazero 0.0.0
......!....!..
Running test suite WASI C tests [wasm32-wasip1] with wasmedge version
..............





Running test suite WASI Rust tests [wasm32-wasip3] with wasmtime 38.0.0
.!!................
Running test suite WASI Rust tests [wasm32-wasip3] with pywasm 2.2.0
___________________
Running test suite WASI Rust tests [wasm32-wasip3] with wamr 2.4.1
___________________
Running test suite WASI Rust tests [wasm32-wasip3] with wazero 0.0.0
___________________
Running test suite WASI Rust tests [wasm32-wasip3] with wasmedge version
___________________
Running test suite WASI Rust tests [wasm32-wasip1] with wasmtime 38.0.0
.................!............................
Running test suite WASI Rust tests [wasm32-wasip1] with pywasm 2.2.0
!!!!!!!.!!!!!.!.!!!!.!!!!!!!!!!!!!!!!!!!!!!!!!
Running test suite WASI Rust tests [wasm32-wasip1] with wamr 2.4.1
!!!!!!!.!!!!!.!.!!!!.!!!!!!!!!!!!!!!!!!!!!!!!!
Running test suite WASI Rust tests [wasm32-wasip1] with wazero 0.0.0
!.!.........!..!......!.......!!...!!!!.!.....
Running test suite WASI Rust tests [wasm32-wasip1] with wasmedge version
..............................................
Running test suite WASI Assemblyscript  tests [wasm32-wasip1] with wasmtime 38.0.0
............
Running test suite WASI Assemblyscript  tests [wasm32-wasip1] with pywasm 2.2.0
!...!.......
Running test suite WASI Assemblyscript  tests [wasm32-wasip1] with wamr 2.4.1
...!....!...
Running test suite WASI Assemblyscript  tests [wasm32-wasip1] with wazero 0.0.0
............
Running test suite WASI Assemblyscript  tests [wasm32-wasip1] with wasmedge version
............
===== Test results =====
wasmtime 38.0.0: FAIL: 3/91 tests failed
  ../wasmtime/target/release/wasmtime -Wcomponent-model-async=y -Sp3=y tests/rust/testsuite/wasm32-wasip3/http-fields.wasm
  ../wasmtime/target/release/wasmtime -Wcomponent-model-async=y -Sp3=y tests/rust/testsuite/wasm32-wasip3/test-stat-at-root.wasm
  ../wasmtime/target/release/wasmtime -Wcomponent-model-async=y -Sp3=y --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/remove_directory_trailing_slashes.wasm fs-tests.dir
pywasm 2.2.0: FAIL: 47/72 tests failed (19 skipped)
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/pwrite-with-access.wasm
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/fdopendir-with-access.wasm
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/pread-with-access.wasm
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/truncation_rights.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_preopen.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_filestat.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/dangling_symlink.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_filestat_set.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/symlink_loop.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_rename.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_exists.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_flags_set.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/isatty.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/dangling_fd.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/stdio.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_allocate.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_dirfd_not_dir.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/remove_directory_trailing_slashes.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/interesting_paths.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/unlink_file_trailing_slashes.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/directory_seek.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_link.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_truncation.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_rename_dir_trailing_slashes.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/nofollow_errors.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_unbuffered_write.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_create_existing.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_advise.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_readdir.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_read_write.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_fdstat_set_rights.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_seek_tell.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fstflags_validate.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/remove_nonempty_directory.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/renumber.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/overwrite_preopen.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/readlink.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/dir_fd_op_failures.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_symlink_trailing_slashes.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/symlink_filestat.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/close_preopen.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/symlink_create.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_missing.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_nonblock.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm --dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_pread_pwrite.wasm fs-tests.dir
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm tests/assemblyscript/testsuite/wasm32-wasip1/args_sizes_get-multiple-arguments.wasm first 'the "second" arg' 3
  /home/wingo/src/wasip3/wasi-testsuite/tools/run-pywasm tests/assemblyscript/testsuite/wasm32-wasip1/args_get-multiple-arguments.wasm first 'the "second" arg' 3
wamr 2.4.1: FAIL: 51/72 tests failed (19 skipped)
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/pwrite-with-access.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/stat-dev-ino.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/fdopendir-with-access.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/pread-with-access.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/pwrite-with-append.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/fopen-with-access.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/c/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/c/testsuite/wasm32-wasip1/lseek.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/truncation_rights.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_preopen.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_filestat.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/dangling_symlink.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_filestat_set.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/symlink_loop.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_rename.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_exists.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_flags_set.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/isatty.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/dangling_fd.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/stdio.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_allocate.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_dirfd_not_dir.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/remove_directory_trailing_slashes.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/interesting_paths.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/unlink_file_trailing_slashes.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/directory_seek.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_link.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_truncation.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_rename_dir_trailing_slashes.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/nofollow_errors.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_unbuffered_write.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_create_existing.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_advise.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_readdir.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_read_write.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_fdstat_set_rights.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_seek_tell.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fstflags_validate.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/remove_nonempty_directory.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/renumber.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/overwrite_preopen.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/readlink.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/dir_fd_op_failures.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_symlink_trailing_slashes.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/symlink_filestat.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/close_preopen.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/symlink_create.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_missing.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_nonblock.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --map-dir tests/rust/testsuite/wasm32-wasip1/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip1/file_pread_pwrite.wasm fs-tests.dir
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --env a=text --env 'b=escap " ing' --env 'c=new
line' tests/assemblyscript/testsuite/wasm32-wasip1/environ_get-multiple-variables.wasm
  ../wasm-micro-runtime/product-mini/platforms/linux/build/iwasm-2.4.1 --env a=b --env b=c --env c=d tests/assemblyscript/testsuite/wasm32-wasip1/environ_sizes_get-multiple-variables.wasm
wazero 0.0.0: FAIL: 14/72 tests failed (19 skipped)
  ../wazero/wazero run -hostlogging=filesystem tests/c/testsuite/wasm32-wasip1/sock_shutdown-not_sock.wasm
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/c/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/c/testsuite/wasm32-wasip1/pwrite-with-append.wasm
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/truncation_rights.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_filestat.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/stdio.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem tests/rust/testsuite/wasm32-wasip1/poll_oneoff_stdio.wasm
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_link.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/path_open_read_write.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/fd_fdstat_set_rights.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/renumber.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/overwrite_preopen.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/readlink.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/dir_fd_op_failures.wasm fs-tests.dir
  ../wazero/wazero run -hostlogging=filesystem -mount=tests/rust/testsuite/wasm32-wasip1/fs-tests.dir:fs-tests.dir tests/rust/testsuite/wasm32-wasip1/symlink_filestat.wasm fs-tests.dir
wasmedge version: PASS: 72 tests passed (19 skipped)
```

There are a few blank lines in the middle; not sure what that's about.  Wizard runs but hangs on one of the tests, and we don't have a timeout in place (https://github.com/titzer/wizard-engine/issues/495).  Otherwise when you see a `_` instead of a `.` that means that a test is skipped, and it is grey instead of green.