### PR TITLE
Add adapter for jco

### DIFF
--- a/adapters/jco.py
+++ b/adapters/jco.py
@@ -1,0 +1,39 @@
+import subprocess
+import os
+import shlex
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# shlex.split() splits according to shell quoting rules
+JCO = shlex.split(os.getenv("JCO", "jco"))
+
+
+def get_name() -> str:
+    return "jco"
+
+
+def get_version() -> str:
+    result = subprocess.run(JCO + ["--version"],
+                            encoding="UTF-8", capture_output=True,
+                            check=True)
+    return result.stdout.strip()
+
+
+def get_wasi_versions() -> List[str]:
+    return ["wasm32-wasip2", "wasm32-wasip3"]
+
+
+def compute_argv(test_path: str,
+                 args: List[str],
+                 env: Dict[str, str],
+                 dirs: List[Tuple[Path, str]],
+                 wasi_version: str) -> List[str]:
+    argv = [] + JCO
+    argv += ["run"]
+    for k, v in env.items():
+        argv += ["--env", f"{k}={v}"]
+    for host, guest in dirs:
+        argv += ["--dir", f"{host}::{guest}"]  # noqa: E231
+    argv += [test_path]
+    argv += args
+    return argv


### PR DESCRIPTION
This PR adds support for jco.  However, nothing passes yet:

 - `jco run` needs `--env` and `--dir` argument support
 - jco doesn't yet support some of the component model (lowering async imports, i think)
 - jco only does wasip2 and wasip3 IIUC

Sample run:
```
~/src/wasip3/wasi-testsuite$ JCO="npx --prefix=../jco jco" ./run-tests -r adapters/jco.py 
Running test suite WASI C tests [wasm32-wasip1] with jco 1.15.0
______________

Running test suite WASI Rust tests [wasm32-wasip3] with jco 1.15.0
!!!!!!!!!!!!!!!!!!!
Running test suite WASI Rust tests [wasm32-wasip1] with jco 1.15.0
______________________________________________
Running test suite WASI Assemblyscript  tests [wasm32-wasip1] with jco 1.15.0
____________
===== Test results =====
jco 1.15.0: FAIL: 19/19 tests failed (72 skipped)
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-mkdir-rmdir.wasm
  npx --prefix=../jco jco run tests/rust/testsuite/wasm32-wasip3/http-fields.wasm
  npx --prefix=../jco jco run tests/rust/testsuite/wasm32-wasip3/test-stat-at-root.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-stat.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-read-directory.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-io.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-is-same-object.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-symbolic-links.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-rename.wasm
  npx --prefix=../jco jco run tests/rust/testsuite/wasm32-wasip3/monotonic-clock.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-open-errors.wasm
  npx --prefix=../jco jco run tests/rust/testsuite/wasm32-wasip3/multi-clock-wait.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-metadata-hash.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-unlink-errors.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-flags-and-type.wasm
  npx --prefix=../jco jco run tests/rust/testsuite/wasm32-wasip3/wall-clock.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-hard-links.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-advise.wasm
  npx --prefix=../jco jco run --dir tests/rust/testsuite/wasm32-wasip3/fs-tests.dir::fs-tests.dir tests/rust/testsuite/wasm32-wasip3/filesystem-set-size.wasm
```

Cc @vados-cosmonic.