### PR TITLE
Upstream clocks tests from wasmtime

### DIFF
--- a/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
@@ -1,0 +1,65 @@
+extern crate wit_bindgen;
+
+wit_bindgen::generate!({
+    inline: r"
+  package test:test;
+
+  world test {
+      include wasi:clocks/imports@0.3.0-rc-2025-09-16;
+      include wasi:cli/command@0.3.0-rc-2025-09-16;
+  }
+",
+    // Work around https://github.com/bytecodealliance/wasm-tools/issues/2285.
+    features:["clocks-timezone"],
+    generate_all
+});
+
+use core::future::Future;
+use core::pin::pin;
+use core::task::{Context, Poll, Waker};
+use wasi::clocks::monotonic_clock;
+
+struct Component;
+export!(Component);
+impl exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        sleep_10ms().await;
+        sleep_0ms();
+        sleep_backwards_in_time();
+        Ok(())
+    }
+}
+
+async fn sleep_10ms() {
+    let dur = 10_000_000;
+    monotonic_clock::wait_until(monotonic_clock::now() + dur).await;
+    monotonic_clock::wait_for(dur).await;
+}
+
+fn sleep_0ms() {
+    let mut cx = Context::from_waker(Waker::noop());
+
+    assert_eq!(
+        pin!(monotonic_clock::wait_until(monotonic_clock::now())).poll(&mut cx),
+        Poll::Ready(()),
+        "waiting until now() is ready immediately",
+    );
+    assert_eq!(
+        pin!(monotonic_clock::wait_for(0)).poll(&mut cx),
+        Poll::Ready(()),
+        "waiting for 0 is ready immediately",
+    );
+}
+
+fn sleep_backwards_in_time() {
+    let mut cx = Context::from_waker(Waker::noop());
+
+    assert_eq!(
+        pin!(monotonic_clock::wait_until(monotonic_clock::now() - 1)).poll(&mut cx),
+        Poll::Ready(()),
+        "waiting until instant which has passed is ready immediately",
+    );
+}
+
+fn main() {}
+

--- a/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
@@ -5,8 +5,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:clocks/imports@0.3.0-rc-2025-09-16;
-      include wasi:cli/command@0.3.0-rc-2025-09-16;
+      include wasi:clocks/imports@0.3.0-rc-2026-02-09;
+      include wasi:cli/command@0.3.0-rc-2026-02-09;
   }
 ",
     // Work around https://github.com/bytecodealliance/wasm-tools/issues/2285.

--- a/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
@@ -35,14 +35,20 @@ async fn sleep_10ms_wait_for() {
     let dur = 10_000_000;
     let deadline = monotonic_clock::now() + dur;
     monotonic_clock::wait_for(dur).await;
-    assert!(monotonic_clock::now() >= deadline, "wait_for never resolves before the deadline");
+    assert!(
+        monotonic_clock::now() >= deadline,
+        "wait_for never resolves before the deadline"
+    );
 }
 
 async fn sleep_10ms_wait_until() {
     let dur = 10_000_000;
     let deadline = monotonic_clock::now() + dur;
     monotonic_clock::wait_until(deadline).await;
-    assert!(monotonic_clock::now() >= deadline, "wait_until never resolves before the deadline");
+    assert!(
+        monotonic_clock::now() >= deadline,
+        "wait_until never resolves before the deadline"
+    );
 }
 
 fn sleep_0ms() {
@@ -71,4 +77,3 @@ fn sleep_backwards_in_time() {
 }
 
 fn main() {}
-

--- a/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/clocks-sleep.rs
@@ -23,17 +23,26 @@ struct Component;
 export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
-        sleep_10ms().await;
+        sleep_10ms_wait_for().await;
+        sleep_10ms_wait_until().await;
         sleep_0ms();
         sleep_backwards_in_time();
         Ok(())
     }
 }
 
-async fn sleep_10ms() {
+async fn sleep_10ms_wait_for() {
     let dur = 10_000_000;
-    monotonic_clock::wait_until(monotonic_clock::now() + dur).await;
+    let deadline = monotonic_clock::now() + dur;
     monotonic_clock::wait_for(dur).await;
+    assert!(monotonic_clock::now() >= deadline, "wait_for never resolves before the deadline");
+}
+
+async fn sleep_10ms_wait_until() {
+    let dur = 10_000_000;
+    let deadline = monotonic_clock::now() + dur;
+    monotonic_clock::wait_until(deadline).await;
+    assert!(monotonic_clock::now() >= deadline, "wait_until never resolves before the deadline");
 }
 
 fn sleep_0ms() {


### PR DESCRIPTION
This upstreams the [WASI clocks tests](https://github.com/bytecodealliance/wasmtime/blob/bd7b59dad0923097760eb73103582252fcd2f408/crates/test-programs/src/bin/p3_clocks_sleep.rs) from Wasmtime. This makes progress towards #181, porting a single test to make sure I'm doing things right. Once we land this, I'd like to port the remainder of the tests in bulk.

As I mentioned in #181 as well: I expect there to be some overlap between this test and the existing WASI 0.3 clocks test. Ideally what I'd like to do is finish porting all tests over first, and then move to refactor/de-duplicate some of the tests. My hope is that with that we can unblock Jco from moving onto `wasi-testsuite` sooner, delete the WASI 0.3 tests from Wasmtime, and focus more of the effort on updating the shared testsuite here. Thanks!