### PR TITLE
Update Rust wasip3 toolchain

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -51,11 +51,11 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
 
-      - name: Install nightly wasm32-wasip2 target for Rust
+      - name: Install nightly wasm32-wasip3 target for Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
-          target: wasm32-wasip2
+          target: wasm32-wasip3
 
       - name: Install stable wasm32-wasip1 target for Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/doc/writing-tests.md
+++ b/doc/writing-tests.md
@@ -90,11 +90,8 @@ rustup toolchain install stable
 rustup toolchain install nightly # needed for wasip3, for now
 rustup default stable
 rustup +stable target add wasm32-wasip1
-rustup +nightly target add wasm32-wasip2 # for wasip3
+rustup +nightly target add wasm32-wasip3
 ```
-
-Note that until wasip3 is released, we use the wasip2 toolchain for
-wasip3.
 
 Now you can run `build.py`.  For Rust, run as `./build.py
 --toolchain=wasm32-wasip3:nightly`, so as to use the nightly channel

--- a/tests/c/build.py
+++ b/tests/c/build.py
@@ -25,12 +25,6 @@ VERSIONS = ['wasip1'] # + ['wasip2', 'wasip3']
 def compute_target(system, version):
     return f"{system}-{version}"
 
-def compute_cc_target(system, version):
-    if version == 'wasip3':
-        # wasm32-wasip3 triple not yet supported.
-        return compute_target(system, 'wasip2')
-    return compute_target(system, version)
-
 BASE_DIR = Path(__file__).parent
 
 def maybe_stat(path, default):
@@ -85,7 +79,7 @@ for system in SYSTEMS:
 
         target_dir = BASE_DIR / "testsuite" / target
         mkdir_p(target_dir)
-        target_args = [f"--target={compute_cc_target(system, version)}"]
+        target_args = [f"--target={compute_target(system, version)}"]
 
         write_manifest(target_dir / "manifest.json",
                        {'name': f"WASI C tests [{target}]"})

--- a/tests/rust/build.py
+++ b/tests/rust/build.py
@@ -40,12 +40,6 @@ VERSIONS = ['wasip1', 'wasip3']
 def compute_target(system, version):
     return f"{system}-{version}"
 
-def compute_build_target(system, version):
-    if version == 'wasip3':
-        # wasm32-wasip3 triple not yet supported.
-        return compute_target(system, 'wasip2')
-    return compute_target(system, version)
-
 BASE_DIR = Path(__file__).parent
 
 def run(argv):
@@ -103,20 +97,19 @@ def mkdir_p(path):
 for system in SYSTEMS:
     for version in VERSIONS:
         target = compute_target(system, version)
-        build_target = compute_build_target(system, version)
         build_mode = "release" if args.release else "debug"
         toolchain = [f"+{TOOLCHAINS[target]}"] if target in TOOLCHAINS else []
 
         build_args = CARGO + toolchain + [
             "build",
             f"--manifest-path={BASE_DIR / target / 'Cargo.toml'}",
-            f"--target={build_target}"
+            f"--target={target}"
         ]
         if args.release:
             build_args.append("--release")
         run(build_args)
 
-        obj_dir = BASE_DIR / target / "target" / build_target / build_mode
+        obj_dir = BASE_DIR / target / "target" / target / build_mode
         src_dir = BASE_DIR / target / "src" / "bin"
         dst_dir = BASE_DIR / "testsuite" / target
         mkdir_p(dst_dir)


### PR DESCRIPTION
Now that nightly has a wasip3 target, let's use it.