### PR TITLE
Introduce the `http` module

### DIFF
--- a/tests/rust/wasm32-wasip3/src/bin/http-fields.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/http-fields.rs
@@ -1,21 +1,5 @@
-extern crate wit_bindgen;
-
-wit_bindgen::generate!({
-    inline: r"
-  package test:test;
-
-  world test {
-      import wasi:http/types@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
-  }
-",
-    additional_derives: [PartialEq, Eq, Hash, Clone],
-    features:["clocks-timezone"],
-    generate_all
-});
-
-use wasi::http::types::Fields;
-use wasi::http::types::HeaderError;
+use test_wasm32_wasip3::cli::{export, exports::wasi::cli::run::Guest};
+use test_wasm32_wasip3::http::wasi::http::types::{Fields, HeaderError};
 
 fn test_empty_fields_inner(fields: Fields) {
     assert!(!fields.has("foo"));
@@ -348,7 +332,7 @@ fn test_field_name_case_insensitivity() {
 
 struct Component;
 export!(Component);
-impl exports::wasi::cli::run::Guest for Component {
+impl Guest for Component {
     async fn run() -> Result<(), ()> {
         test_empty_fields();
         test_fields_with_foo();

--- a/tests/rust/wasm32-wasip3/src/bin/http-request.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/http-request.rs
@@ -1,20 +1,8 @@
-extern crate wit_bindgen;
-
-wit_bindgen::generate!({
-    inline: r"
-  package test:test;
-
-  world test {
-      import wasi:http/types@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
-  }
-",
-    additional_derives: [PartialEq, Eq, Hash, Clone],
-    features:["clocks-timezone"],
-    generate_all
-});
-
-use wasi::http::types::{Fields, HeaderError, Method, Request, Scheme};
+use test_wasm32_wasip3::cli::{export, exports::wasi::cli::run::Guest};
+use test_wasm32_wasip3::http::{
+    wasi::http::types::{Fields, HeaderError, Method, Request, Scheme},
+    wit_future,
+};
 
 fn test_request_field_default_values(request: &Request) {
     assert_eq!(request.get_method(), Method::Get);
@@ -284,7 +272,7 @@ fn test() {
 struct Component;
 export!(Component);
 
-impl exports::wasi::cli::run::Guest for Component {
+impl Guest for Component {
     async fn run() -> Result<(), ()> {
         test();
         Ok(())

--- a/tests/rust/wasm32-wasip3/src/bin/http-response.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/http-response.rs
@@ -1,20 +1,8 @@
-extern crate wit_bindgen;
-
-wit_bindgen::generate!({
-    inline: r"
-  package test:test;
-
-  world test {
-      import wasi:http/types@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
-  }
-",
-    additional_derives: [PartialEq, Eq, Hash, Clone],
-    features:["clocks-timezone"],
-    generate_all
-});
-
-use wasi::http::types::{Fields, HeaderError, Response};
+use test_wasm32_wasip3::cli::{export, exports::wasi::cli::run::Guest};
+use test_wasm32_wasip3::http::{
+    wasi::http::types::{Fields, HeaderError, Response},
+    wit_future,
+};
 
 fn test_response_field_default_values(response: &Response) {
     assert_eq!(response.get_status_code(), 200);
@@ -65,7 +53,7 @@ async fn test_response() -> Response {
 struct Component;
 export!(Component);
 
-impl exports::wasi::cli::run::Guest for Component {
+impl Guest for Component {
     async fn run() -> Result<(), ()> {
         test_response().await;
         Ok(())

--- a/tests/rust/wasm32-wasip3/src/http.rs
+++ b/tests/rust/wasm32-wasip3/src/http.rs
@@ -1,0 +1,14 @@
+wit_bindgen::generate!({
+    inline: r"
+	package wasi-testsuite:test;
+
+	world http-test {
+	    import wasi:http/types@0.3.0-rc-2026-02-09;
+	}
+    ",
+    additional_derives: [PartialEq, Eq, Hash, Clone],
+    pub_export_macro: true,
+    default_bindings_module: "test_wasm32_wasip3::http",
+    features:["clocks-timezone"],
+    generate_all
+});

--- a/tests/rust/wasm32-wasip3/src/lib.rs
+++ b/tests/rust/wasm32-wasip3/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
 pub mod clocks;
+pub mod http;
 pub mod random;
 pub mod sockets;


### PR DESCRIPTION
Similar to all the other existing tests, this change introduces an `http` module to avoid the `wit_bindgen::generate` macro call at the top of each test.