### PR TITLE
Rework "run vs serve" logic to require explicit wasi world

### DIFF
--- a/adapters/pywasm.py
+++ b/adapters/pywasm.py
@@ -27,9 +27,15 @@ def get_version() -> str:
 def get_wasi_versions() -> List[str]:
     return ["wasm32-wasip1"]
 
+
+def get_wasi_worlds() -> List[str]:
+    return ["wasi:cli/command"]
+
+
 def compute_argv(test_path: str,
                  args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
                  proposals: List[str],
+                 wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []

--- a/adapters/wasm-micro-runtime.py
+++ b/adapters/wasm-micro-runtime.py
@@ -28,9 +28,14 @@ def get_wasi_versions() -> List[str]:
     return ["wasm32-wasip1"]
 
 
+def get_wasi_worlds() -> List[str]:
+    return ["wasi:cli/command"]
+
+
 def compute_argv(test_path: str,
                  args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
                  proposals: List[str],
+                 wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []

--- a/adapters/wasmedge.py
+++ b/adapters/wasmedge.py
@@ -28,9 +28,14 @@ def get_wasi_versions() -> List[str]:
     return ["wasm32-wasip1"]
 
 
+def get_wasi_worlds() -> List[str]:
+    return ["wasi:cli/command"]
+
+
 def compute_argv(test_path: str,
                  args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
                  proposals: List[str],
+                 wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []

--- a/adapters/wasmtime.py
+++ b/adapters/wasmtime.py
@@ -25,9 +25,14 @@ def get_wasi_versions() -> List[str]:
     return ["wasm32-wasip1", "wasm32-wasip3"]
 
 
+def get_wasi_worlds() -> List[str]:
+    return ["wasi:cli/command", "wasi:http/service"]
+
+
 def compute_argv(test_path: str,
                  args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
                  proposals: List[str],
+                 wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []
@@ -43,17 +48,26 @@ def compute_argv(test_path: str,
     argv += [test_path]
 
     argv += args
-    _add_wasi_version_options(argv, wasi_version, proposals)
+    _add_wasi_version_options(argv, wasi_version, proposals, wasi_world)
     return argv
 
 
 # The user might provide WASMTIME="wasmtime --option -Sfoo".  Let's
 # insert the options to choose the WASI version before the user's
 # options, so that the user can override our choices.
-def _add_wasi_version_options(argv: List[str], wasi_version: str, proposals: List[str]) -> None:
+def _add_wasi_version_options(argv: List[str], wasi_version: str,
+                              proposals: List[str], wasi_world: str) -> None:
     splice_pos = len(WASMTIME)
     while splice_pos > 1 and argv[splice_pos - 1].startswith("-"):
         splice_pos -= 1
+    match wasi_world:
+        case "wasi:cli/command":
+            pass
+        case "wasi:http/service":
+            argv[splice_pos:splice_pos] = \
+                ["serve", "-Scli", "--addr=127.0.0.1:0"]
+            splice_pos += 1
+
     match wasi_version:
         case "wasm32-wasip1":
             pass
@@ -63,13 +77,6 @@ def _add_wasi_version_options(argv: List[str], wasi_version: str, proposals: Lis
                 flags_from_proposals += ",http"
             if "sockets" in proposals:
                 flags_from_proposals += ",inherit-network"
-            if "http/service" in proposals:
-                flags_from_proposals += ",cli"
-                argv[splice_pos:splice_pos] = ["serve", "--addr=127.0.0.1:0"]
-                splice_pos += 1
 
             argv[splice_pos:splice_pos] = ["-Wcomponent-model-async",
                                            f"-Sp3{flags_from_proposals}"]
-
-        case _:
-            pass

--- a/adapters/wazero.py
+++ b/adapters/wazero.py
@@ -30,9 +30,14 @@ def get_wasi_versions() -> List[str]:
     return ["wasm32-wasip1"]
 
 
+def get_wasi_worlds() -> List[str]:
+    return ["wasi:cli/command"]
+
+
 def compute_argv(test_path: str,
                  args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
                  proposals: List[str],
+                 wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []

--- a/adapters/wizard.py
+++ b/adapters/wizard.py
@@ -36,9 +36,14 @@ def get_wasi_versions() -> List[str]:
     return ["wasm32-wasip1"]
 
 
+def get_wasi_worlds() -> List[str]:
+    return ["wasi:cli/command"]
+
+
 def compute_argv(test_path: str,
                  args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
                  proposals: List[str],
+                 wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []

--- a/test-runner/tests/test_test_suite.py
+++ b/test-runner/tests/test_test_suite.py
@@ -21,7 +21,8 @@ def test_test_suite_should_return_correct_count() -> None:
         ts.TestSuiteMeta("suite",
                          tc.WasiVersion.WASM32_WASIP1,
                          RuntimeMeta("test-runtime", "3.14",
-                                     frozenset([tc.WasiVersion.WASM32_WASIP1]))),
+                                     frozenset([tc.WasiVersion.WASM32_WASIP1]),
+                                     frozenset([tc.WasiWorld.CLI_COMMAND]))),
         10.0,
         datetime.now(),
         [

--- a/test-runner/tests/test_test_suite_runner.py
+++ b/test-runner/tests/test_test_suite_runner.py
@@ -78,8 +78,10 @@ def test_runner_end_to_end() -> None:
     runtime_version_str = "4.2"
     the_runtime_wasi_version = tc.WasiVersion.WASM32_WASIP1
     runtime_wasi_versions = frozenset([the_runtime_wasi_version])
+    runtime_wasi_worlds = frozenset([tc.WasiWorld.CLI_COMMAND])
     runtime_meta = RuntimeMeta(runtime_name, runtime_version_str,
-                               runtime_wasi_versions)
+                               runtime_wasi_versions,
+                               runtime_wasi_worlds)
 
     expected_test_suite_meta = ts.TestSuiteMeta(test_suite_name,
                                                 the_runtime_wasi_version,
@@ -139,7 +141,8 @@ def test_runner_end_to_end() -> None:
         assert filt.should_skip.call_count == 4
         for test_case in expected_test_cases:
             filt.should_skip.assert_any_call(expected_test_suite_meta,
-                                             test_case.name)
+                                             test_case.name,
+                                             test_case.config)
 
 
 @patch("os.path.exists", Mock(return_value=False))

--- a/test-runner/tests/test_test_suite_runner.py
+++ b/test-runner/tests/test_test_suite_runner.py
@@ -17,7 +17,8 @@ def get_mock_open() -> Mock:
             "my-path/test3.json": '{"stdout": "output", "env": {"x": "1"}}',
             "my-path/test4.json": (
                 '{"operations": [{"type": "run"}, {"type": "wait", "exit_code": 1}], '
-                '"proposals": []}'
+                '"proposals": [], '
+                '"world": "wasi:http/service"}'
             ),
         }
         if filename in file_content:
@@ -54,19 +55,23 @@ def test_runner_end_to_end() -> None:
                 tc.Run(dirs=[(Path(test_suite_dir) / d, d) for d in test_dirs]),
                 tc.Wait(exit_code=0)
             ],
-            proposals=[]
+            proposals=[],
+            world=tc.WasiWorld.CLI_COMMAND
         ),
         tc.Config(
             operations=[tc.Run(args=["a", "b"]), tc.Wait(exit_code=1)],
-            proposals=[]
+            proposals=[],
+            world=tc.WasiWorld.CLI_COMMAND
         ),
         tc.Config(
             operations=[tc.Run(env={"x": "1"}), tc.Read(id="stdout", payload="output"), tc.Wait(exit_code=0)],
-            proposals=[]
+            proposals=[],
+            world=tc.WasiWorld.CLI_COMMAND
         ),
         tc.Config(
             operations=[tc.Run(), tc.Wait(exit_code=1)],
-            proposals=[]
+            proposals=[],
+            world=tc.WasiWorld.HTTP_SERVICE
         ),
     ]
 

--- a/test-runner/wasi_test_runner/runtime_adapter.py
+++ b/test-runner/wasi_test_runner/runtime_adapter.py
@@ -11,6 +11,7 @@ class RuntimeMeta(NamedTuple):
     name: str
     version: str
     supported_wasi_versions: frozenset[WasiVersion]
+    supported_wasi_worlds: frozenset[WasiWorld]
 
     def __str__(self) -> str:
         return f"{self.name} {self.version}"
@@ -83,11 +84,14 @@ class RuntimeAdapter:
             wasi_versions = frozenset(
                 WasiVersion(v) for v in self._adapter.get_wasi_versions()
             )
+            wasi_worlds = frozenset(
+                WasiWorld(w) for w in self._adapter.get_wasi_worlds()
+            )
         except subprocess.CalledProcessError as e:
             raise UnavailableRuntimeAdapterError(adapter_path, e) from e
         except FileNotFoundError as e:
             raise UnavailableRuntimeAdapterError(adapter_path, e) from e
-        self._meta = RuntimeMeta(name, version, wasi_versions)
+        self._meta = RuntimeMeta(name, version, wasi_versions, wasi_worlds)
 
     def get_meta(self) -> RuntimeMeta:
         return self._meta

--- a/test-runner/wasi_test_runner/runtime_adapter.py
+++ b/test-runner/wasi_test_runner/runtime_adapter.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import NamedTuple, List, Tuple, Dict, Any
 
-from .test_case import WasiVersion
+from .test_case import WasiVersion, WasiWorld
 
 
 class RuntimeMeta(NamedTuple):
@@ -93,9 +93,11 @@ class RuntimeAdapter:
         return self._meta
 
     def compute_argv(self, test_path: str,
-                     args: List[str], env: Dict[str, str],
+                     args: List[str],
+                     env: Dict[str, str],
                      dirs: List[Tuple[Path, str]],
                      proposals: List[str],
+                     wasi_world: WasiWorld,
                      wasi_version: WasiVersion) -> List[str]:
         # too-many-positional-arguments is a post-3.0 pylint message.
         # pylint: disable-msg=unknown-option-value
@@ -103,7 +105,8 @@ class RuntimeAdapter:
         # pylint: disable-msg=too-many-positional-arguments
         args_env_dirs = [args, env, dirs]
         argv = self._adapter.compute_argv(test_path, args_env_dirs,
-                                          proposals, wasi_version.value)
+                                          proposals, wasi_world.value,
+                                          wasi_version.value)
         assert isinstance(argv, list)
         assert all(isinstance(arg, str) for arg in argv)
         return argv

--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -110,7 +110,7 @@ class TestCaseRunner(TestCaseRunnerBase):
         proposals = self.config.proposals_as_str()
         argv = self._runtime.compute_argv(
             self._test_path, run.args, run.env, run.dirs, proposals,
-            self._wasi_version)
+            self.config.world, self._wasi_version)
         self._last_argv = argv
         try:
             # pylint: disable-msg=consider-using-with

--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -265,17 +265,24 @@ def run_tests_from_test_suite(
     meta = TestSuiteMeta(manifest.name, manifest.wasi_version,
                          runtime.get_meta())
 
-    for test_path in glob.glob(os.path.join(test_suite_path, "*.wasm")):
-        test_name = os.path.splitext(os.path.basename(test_path))[0]
+    all_tests = [
+        (test_path,
+         os.path.splitext(os.path.basename(test_path))[0],
+         _read_test_config(test_path))
+        for test_path in glob.glob(os.path.join(test_suite_path, "*.wasm"))
+    ]
+
+    for test_path, name, config in all_tests:
         for filt in filters:
             # for now, just drop the skip reason string. it might be
             # useful to make reporters report it.
-            skip, _ = filt.should_skip(meta, test_name)
+            skip, _ = filt.should_skip(meta, name, config)
             if skip:
-                test_case = _skip_single_test(test_path)
+                test_case = _skip_single_test(name, config)
                 break
         else:
-            test_case = _execute_single_test(runtime, meta, test_path)
+            test_case = _execute_single_test(
+                runtime, meta, test_path, name, config)
         test_cases.append(test_case)
         for reporter in reporters:
             reporter.report_test(meta, test_case)
@@ -290,10 +297,9 @@ def run_tests_from_test_suite(
     )
 
 
-def _skip_single_test(test_path: str) -> TestCase:
-    config = _read_test_config(test_path)
+def _skip_single_test(name: str, config: Config) -> TestCase:
     return TestCase(
-        name=os.path.splitext(os.path.basename(test_path))[0],
+        name=name,
         argv=[],
         config=config,
         result=Result(is_executed=False, failures=[]),
@@ -320,16 +326,16 @@ def _cleanup_test_output(host_dir: Path) -> None:
 
 
 def _execute_single_test(
-    runtime: RuntimeAdapter, meta: TestSuiteMeta, test_path: str
+        runtime: RuntimeAdapter, meta: TestSuiteMeta, test_path: str,
+        name: str, config: Config
 ) -> TestCase:
-    config = _read_test_config(test_path)
     runner = TestCaseRunner(config, test_path, meta.wasi_version, runtime)
     test_start = time.time()
     result = runner.run()
     elapsed = time.time() - test_start
 
     return TestCase(
-        name=os.path.splitext(os.path.basename(test_path))[0],
+        name=name,
         argv=runner.last_argv(),
         config=config,
         result=result,

--- a/tests/rust/wasm32-wasip3/src/bin/http-service.json
+++ b/tests/rust/wasm32-wasip3/src/bin/http-service.json
@@ -1,5 +1,6 @@
 {
-  "proposals": ["http", "http/service"],
+  "proposals": ["http"],
+  "world": "wasi:http/service",
   "operations": [
     { "type": "run" },
     { "type": "request",


### PR DESCRIPTION
* adapters/pywasm.py:
* adapters/wasm-micro-runtime.py:
* adapters/wasmedge.py:
* adapters/wasmtime.py:
* adapters/wazero.py:
* adapters/wizard.py: Take a WASI world as an additional argument.
* test-runner/tests/test_test_case.py:
* test-runner/tests/test_test_suite_runner.py: Update tests.
* test-runner/wasi_test_runner/runtime_adapter.py: Plumb wasi_world through to runtime.
* test-runner/wasi_test_runner/test_case.py (WasiWorld): New type. (WasiProposal): Remove http/service, it's not a proposal. (Config.from_file): Don't infer proposals from ops.  Parse out a world.
* test-runner/wasi_test_runner/test_suite_runner.py (TestCaseRunner.do_run): Pass world to adapter.
* tests/rust/wasm32-wasip3/src/bin/http-service.json: Adapt.