### PR TITLE
Bump to 0.3.0-rc-2026-03-15

### DIFF
--- a/tests/rust/wasm32-wasip3/Cargo.lock
+++ b/tests/rust/wasm32-wasip3/Cargo.lock
@@ -4,15 +4,15 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "equivalent"
@@ -28,9 +28,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -53,15 +53,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -70,15 +70,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -87,21 +87,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -111,7 +111,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -150,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "leb128fmt"
@@ -162,27 +161,21 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -196,33 +189,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -255,27 +242,28 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -292,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -422,3 +410,9 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-dotdot.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-dotdot.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-io.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-io.rs
@@ -7,8 +7,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-      include wasi:cli/command@0.3.0-rc-2026-02-09;
+      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+      include wasi:cli/command@0.3.0-rc-2026-03-15;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-echo.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-echo.rs
@@ -3,8 +3,8 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world test {
-	    include wasi:sockets/imports@0.3.0-rc-2026-02-09;
-	    include wasi:cli/command@0.3.0-rc-2026-02-09;
+	    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
+	    include wasi:cli/command@0.3.0-rc-2026-03-15;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
@@ -3,8 +3,8 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world test {
-	    include wasi:sockets/imports@0.3.0-rc-2026-02-09;
-	    include wasi:cli/command@0.3.0-rc-2026-02-09;
+	    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
+	    include wasi:cli/command@0.3.0-rc-2026-03-15;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/cli.rs
+++ b/tests/rust/wasm32-wasip3/src/cli.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world cli-test {
-		include wasi:cli/command@0.3.0-rc-2026-02-09;
+		include wasi:cli/command@0.3.0-rc-2026-03-15;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/clocks.rs
+++ b/tests/rust/wasm32-wasip3/src/clocks.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world clocks-test {
-		include wasi:clocks/imports@0.3.0-rc-2026-02-09;
+		include wasi:clocks/imports@0.3.0-rc-2026-03-15;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/http.rs
+++ b/tests/rust/wasm32-wasip3/src/http.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world http-test {
-	    include wasi:http/service@0.3.0-rc-2026-02-09;
+	    include wasi:http/service@0.3.0-rc-2026-03-15;
 	}
     ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/random.rs
+++ b/tests/rust/wasm32-wasip3/src/random.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world random-test {
-		include wasi:random/imports@0.3.0-rc-2026-02-09;
+		include wasi:random/imports@0.3.0-rc-2026-03-15;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/sockets.rs
+++ b/tests/rust/wasm32-wasip3/src/sockets.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world test {
-	    include wasi:sockets/imports@0.3.0-rc-2026-02-09;
+	    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-cli-0.3.0-rc-2026-03-15/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-cli-0.3.0-rc-2026-03-15/package.wit
@@ -1,6 +1,6 @@
-package wasi:cli@0.3.0-rc-2026-02-09;
+package wasi:cli@0.3.0-rc-2026-03-15;
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface environment {
   /// Get the POSIX-style environment variables.
   ///
@@ -10,23 +10,23 @@ interface environment {
   /// Morally, these are a value import, but until value imports are available
   /// in the component model, this import function should return the same
   /// values each time it is called.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-environment: func() -> list<tuple<string, string>>;
 
   /// Get the POSIX-style arguments to the program.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-arguments: func() -> list<string>;
 
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-initial-cwd: func() -> option<string>;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface exit {
   /// Exit the current instance and any linked instances.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   exit: func(status: result);
 
   /// Exit the current instance and any linked instances, reporting the
@@ -41,16 +41,16 @@ interface exit {
   exit-with-code: func(status-code: u8);
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface run {
   /// Run the program.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   run: async func() -> result;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface types {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   enum error-code {
     /// Input/output error
     io,
@@ -61,7 +61,7 @@ interface types {
   }
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface stdin {
   use types.{error-code};
 
@@ -78,11 +78,11 @@ interface stdin {
   ///
   /// Multiple streams may be active at the same time. The behavior of concurrent
   /// reads is implementation-specific.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface stdout {
   use types.{error-code};
 
@@ -94,11 +94,11 @@ interface stdout {
   ///
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface stderr {
   use types.{error-code};
 
@@ -110,7 +110,7 @@ interface stderr {
   ///
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 }
 
@@ -119,10 +119,10 @@ interface stderr {
 /// In the future, this may include functions for disabling echoing,
 /// disabling input buffering so that keyboard events are sent through
 /// immediately, querying supported features, and so on.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface terminal-input {
   /// The input side of a terminal.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource terminal-input;
 }
 
@@ -131,126 +131,126 @@ interface terminal-input {
 /// In the future, this may include functions for querying the terminal
 /// size, being notified of terminal size changes, querying supported
 /// features, and so on.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface terminal-output {
   /// The output side of a terminal.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource terminal-output;
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface terminal-stdin {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   use terminal-input.{terminal-input};
 
   /// If stdin is connected to a terminal, return a `terminal-input` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface terminal-stdout {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   use terminal-output.{terminal-output};
 
   /// If stdout is connected to a terminal, return a `terminal-output` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface terminal-stderr {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   use terminal-output.{terminal-output};
 
   /// If stderr is connected to a terminal, return a `terminal-output` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-terminal-stderr: func() -> option<terminal-output>;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world imports {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import environment;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import exit;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import types;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import stdin;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import stdout;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import stderr;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-input;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-output;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-stdin;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-stdout;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-stderr;
-  import wasi:clocks/types@0.3.0-rc-2026-02-09;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-02-09;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-02-09;
+  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-02-09;
-  import wasi:filesystem/types@0.3.0-rc-2026-02-09;
-  import wasi:filesystem/preopens@0.3.0-rc-2026-02-09;
-  import wasi:sockets/types@0.3.0-rc-2026-02-09;
-  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-02-09;
-  import wasi:random/random@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-02-09;
+  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
+  import wasi:filesystem/types@0.3.0-rc-2026-03-15;
+  import wasi:filesystem/preopens@0.3.0-rc-2026-03-15;
+  import wasi:sockets/types@0.3.0-rc-2026-03-15;
+  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15;
+  import wasi:random/random@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
 }
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world command {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import environment;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import exit;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import types;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import stdin;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import stdout;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import stderr;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-input;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-output;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-stdin;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-stdout;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import terminal-stderr;
-  import wasi:clocks/types@0.3.0-rc-2026-02-09;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-02-09;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-02-09;
+  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-02-09;
-  import wasi:filesystem/types@0.3.0-rc-2026-02-09;
-  import wasi:filesystem/preopens@0.3.0-rc-2026-02-09;
-  import wasi:sockets/types@0.3.0-rc-2026-02-09;
-  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-02-09;
-  import wasi:random/random@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-02-09;
+  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
+  import wasi:filesystem/types@0.3.0-rc-2026-03-15;
+  import wasi:filesystem/preopens@0.3.0-rc-2026-03-15;
+  import wasi:sockets/types@0.3.0-rc-2026-03-15;
+  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15;
+  import wasi:random/random@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   export run;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-clocks-0.3.0-rc-2026-03-15/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-clocks-0.3.0-rc-2026-03-15/package.wit
@@ -1,10 +1,10 @@
-package wasi:clocks@0.3.0-rc-2026-02-09;
+package wasi:clocks@0.3.0-rc-2026-03-15;
 
 /// This interface common types used throughout wasi:clocks.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface types {
   /// A duration of time, in nanoseconds.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type duration = u64;
 }
 
@@ -16,14 +16,14 @@ interface types {
 ///
 /// A monotonic clock is a clock which has an unspecified initial value, and
 /// successive reads of the clock will produce non-decreasing values.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface monotonic-clock {
   use types.{duration};
 
   /// A mark on a monotonic clock is a number of nanoseconds since an
   /// unspecified initial value, and can only be compared to instances from
   /// the same monotonic-clock.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type mark = u64;
 
   /// Read the current value of the clock.
@@ -35,20 +35,20 @@ interface monotonic-clock {
   /// the value of the clock in a `mark`. Consequently, implementations
   /// should ensure that the starting time is low enough to avoid the
   /// possibility of overflow in practice.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   now: func() -> mark;
 
   /// Query the resolution of the clock. Returns the duration of time
   /// corresponding to a clock tick.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-resolution: func() -> duration;
 
   /// Wait until the specified mark has occurred.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   wait-until: async func(when: mark);
 
   /// Wait for the specified duration to elapse.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   wait-for: async func(how-long: duration);
 }
 
@@ -62,7 +62,7 @@ interface monotonic-clock {
 /// monotonic, making it unsuitable for measuring elapsed time.
 ///
 /// It is intended for reporting the current date and time for humans.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface system-clock {
   use types.{duration};
 
@@ -82,7 +82,7 @@ interface system-clock {
   ///
   /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
   /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record instant {
     seconds: s64,
     nanoseconds: u32,
@@ -94,12 +94,12 @@ interface system-clock {
   /// will not necessarily produce a sequence of non-decreasing values.
   ///
   /// The nanoseconds field of the output is always less than 1000000000.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   now: func() -> instant;
 
   /// Query the resolution of the clock. Returns the smallest duration of time
   /// that the implementation permits distinguishing.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-resolution: func() -> duration;
 }
 
@@ -148,13 +148,13 @@ interface timezone {
   to-debug-string: func() -> string;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world imports {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import types;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import monotonic-clock;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import system-clock;
   @unstable(feature = clocks-timezone)
   import timezone;

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-filesystem-0.3.0-rc-2026-03-15/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-filesystem-0.3.0-rc-2026-03-15/package.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.3.0-rc-2026-02-09;
+package wasi:filesystem@0.3.0-rc-2026-03-15;
 
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
@@ -35,23 +35,20 @@ package wasi:filesystem@0.3.0-rc-2026-02-09;
 /// store or a database instead.
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface types {
-  @since(version = 0.3.0-rc-2026-02-09)
-  use wasi:clocks/system-clock@0.3.0-rc-2026-02-09.{instant};
+  @since(version = 0.3.0-rc-2026-03-15)
+  use wasi:clocks/system-clock@0.3.0-rc-2026-03-15.{instant};
 
   /// File size or length of a region within a file.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type filesize = u64;
 
   /// The type of a filesystem object referenced by a descriptor.
   ///
   /// Note: This was called `filetype` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-02-09)
-  enum descriptor-type {
-    /// The type of the descriptor or file is unknown or is different from
-    /// any of the other types specified.
-    unknown,
+  @since(version = 0.3.0-rc-2026-03-15)
+  variant descriptor-type {
     /// The descriptor refers to a block device inode.
     block-device,
     /// The descriptor refers to a character device inode.
@@ -66,12 +63,15 @@ interface types {
     regular-file,
     /// The descriptor refers to a socket.
     socket,
+    /// The type of the descriptor or file is different from any of the
+    /// other types specified.
+    other(option<string>),
   }
 
   /// Descriptor flags.
   ///
   /// Note: This was called `fdflags` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   flags descriptor-flags {
     /// Read mode: Data can be read.
     read,
@@ -113,7 +113,7 @@ interface types {
   }
 
   /// Flags determining the method of how paths are resolved.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   flags path-flags {
     /// As long as the resolved path corresponds to a symbolic link, it is
     /// expanded.
@@ -121,7 +121,7 @@ interface types {
   }
 
   /// Open flags used by `open-at`.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   flags open-flags {
     /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
     create,
@@ -134,13 +134,13 @@ interface types {
   }
 
   /// Number of hard links to an inode.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type link-count = u64;
 
   /// File attributes.
   ///
   /// Note: This was called `filestat` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record descriptor-stat {
     /// File type.
     %type: descriptor-type,
@@ -167,7 +167,7 @@ interface types {
   }
 
   /// When setting a timestamp, this gives the value to set it to.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant new-timestamp {
     /// Leave the timestamp set to its previous value.
     no-change,
@@ -179,7 +179,7 @@ interface types {
   }
 
   /// A directory entry.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record directory-entry {
     /// The type of the file referred to by this directory entry.
     %type: descriptor-type,
@@ -191,8 +191,8 @@ interface types {
   /// Not all of these error codes are returned by the functions provided by this
   /// API; some are used in higher-level library layers, and others are provided
   /// merely for alignment with POSIX.
-  @since(version = 0.3.0-rc-2026-02-09)
-  enum error-code {
+  @since(version = 0.3.0-rc-2026-03-15)
+  variant error-code {
     /// Permission denied, similar to `EACCES` in POSIX.
     access,
     /// Connection already in progress, similar to `EALREADY` in POSIX.
@@ -265,10 +265,14 @@ interface types {
     text-file-busy,
     /// Cross-device link, similar to `EXDEV` in POSIX.
     cross-device,
+    /// A catch-all for errors not captured by the existing variants.
+    /// Implementations can use this to extend the error type without
+    /// breaking existing code.
+    other(option<string>),
   }
 
   /// File or memory access pattern advisory information.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   enum advice {
     /// The application has no advice to give on its behavior with respect
     /// to the specified data.
@@ -292,7 +296,7 @@ interface types {
 
   /// A 128-bit hash value, split into parts because wasm doesn't have a
   /// 128-bit integer type.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record metadata-hash-value {
     /// 64 bits of a 128-bit hash value.
     lower: u64,
@@ -303,7 +307,7 @@ interface types {
   /// A descriptor is a reference to a filesystem object, which may be a file,
   /// directory, named pipe, special file, or other object on which filesystem
   /// calls may be made.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource descriptor {
     /// Return a stream for reading from a file.
     ///
@@ -321,7 +325,7 @@ interface types {
     /// resolves to `err` with an `error-code`.
     ///
     /// Note: This is similar to `pread` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
     /// Return a stream for writing to a file, if available.
     ///
@@ -335,7 +339,7 @@ interface types {
     /// written or an error is encountered.
     ///
     /// Note: This is similar to `pwrite` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     write-via-stream: func(data: stream<u8>, offset: filesize) -> future<result<_, error-code>>;
     /// Return a stream for appending to a file, if available.
     ///
@@ -345,12 +349,12 @@ interface types {
     /// written or an error is encountered.
     ///
     /// Note: This is similar to `write` with `O_APPEND` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     append-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
     /// Provide file advisory information on a descriptor.
     ///
     /// This is similar to `posix_fadvise` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     advise: async func(offset: filesize, length: filesize, advice: advice) -> result<_, error-code>;
     /// Synchronize the data of a file to disk.
     ///
@@ -358,7 +362,7 @@ interface types {
     /// opened for writing.
     ///
     /// Note: This is similar to `fdatasync` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     sync-data: async func() -> result<_, error-code>;
     /// Get flags associated with a descriptor.
     ///
@@ -366,7 +370,7 @@ interface types {
     ///
     /// Note: This returns the value that was the `fs_flags` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-flags: async func() -> result<descriptor-flags, error-code>;
     /// Get the dynamic type of a descriptor.
     ///
@@ -378,20 +382,20 @@ interface types {
     ///
     /// Note: This returns the value that was the `fs_filetype` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-type: async func() -> result<descriptor-type, error-code>;
     /// Adjust the size of an open file. If this increases the file's size, the
     /// extra bytes are filled with zeros.
     ///
     /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-size: async func(size: filesize) -> result<_, error-code>;
     /// Adjust the timestamps of an open file or directory.
     ///
     /// Note: This is similar to `futimens` in POSIX.
     ///
     /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-times: async func(data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
     /// Read directory entries from a directory.
     ///
@@ -405,7 +409,7 @@ interface types {
     ///
     /// This function returns a future, which will resolve to an error code if
     /// reading full contents of the directory fails.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     read-directory: func() -> tuple<stream<directory-entry>, future<result<_, error-code>>>;
     /// Synchronize the data and metadata of a file to disk.
     ///
@@ -413,12 +417,12 @@ interface types {
     /// opened for writing.
     ///
     /// Note: This is similar to `fsync` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     sync: async func() -> result<_, error-code>;
     /// Create a directory.
     ///
     /// Note: This is similar to `mkdirat` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     create-directory-at: async func(path: string) -> result<_, error-code>;
     /// Return the attributes of an open file or directory.
     ///
@@ -429,7 +433,7 @@ interface types {
     /// modified, use `metadata-hash`.
     ///
     /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     stat: async func() -> result<descriptor-stat, error-code>;
     /// Return the attributes of a file or directory.
     ///
@@ -438,7 +442,7 @@ interface types {
     /// discussion of alternatives.
     ///
     /// Note: This was called `path_filestat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     stat-at: async func(path-flags: path-flags, path: string) -> result<descriptor-stat, error-code>;
     /// Adjust the timestamps of a file or directory.
     ///
@@ -446,7 +450,7 @@ interface types {
     ///
     /// Note: This was called `path_filestat_set_times` in earlier versions of
     /// WASI.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-times-at: async func(path-flags: path-flags, path: string, data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
     /// Create a hard link.
     ///
@@ -455,7 +459,7 @@ interface types {
     /// `error-code::not-permitted` if the old path is not a file.
     ///
     /// Note: This is similar to `linkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     link-at: async func(old-path-flags: path-flags, old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
     /// Open a file or directory.
     ///
@@ -469,7 +473,7 @@ interface types {
     /// `error-code::read-only`.
     ///
     /// Note: This is similar to `openat` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     open-at: async func(path-flags: path-flags, path: string, open-flags: open-flags, %flags: descriptor-flags) -> result<descriptor, error-code>;
     /// Read the contents of a symbolic link.
     ///
@@ -477,19 +481,19 @@ interface types {
     /// filesystem, this function fails with `error-code::not-permitted`.
     ///
     /// Note: This is similar to `readlinkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     readlink-at: async func(path: string) -> result<string, error-code>;
     /// Remove a directory.
     ///
     /// Return `error-code::not-empty` if the directory is not empty.
     ///
     /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     remove-directory-at: async func(path: string) -> result<_, error-code>;
     /// Rename a filesystem object.
     ///
     /// Note: This is similar to `renameat` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     rename-at: async func(old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
     /// Create a symbolic link (also known as a "symlink").
     ///
@@ -497,13 +501,18 @@ interface types {
     /// `error-code::not-permitted`.
     ///
     /// Note: This is similar to `symlinkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     symlink-at: async func(old-path: string, new-path: string) -> result<_, error-code>;
     /// Unlink a filesystem object that is not a directory.
     ///
-    /// Return `error-code::is-directory` if the path refers to a directory.
-    /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
-    @since(version = 0.3.0-rc-2026-02-09)
+    /// This is similar to `unlinkat(fd, path, 0)` in POSIX.
+    ///
+    /// Error returns are as specified by POSIX.
+    ///
+    /// If the filesystem object is a directory, `error-code::access` or
+    /// `error-code::is-directory` may be returned instead of the
+    /// POSIX-specified `error-code::not-permitted`.
+    @since(version = 0.3.0-rc-2026-03-15)
     unlink-file-at: async func(path: string) -> result<_, error-code>;
     /// Test whether two descriptors refer to the same filesystem object.
     ///
@@ -511,7 +520,7 @@ interface types {
     /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
     /// wasi-filesystem does not expose device and inode numbers, so this function
     /// may be used instead.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     is-same-object: async func(other: borrow<descriptor>) -> bool;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a descriptor.
@@ -532,35 +541,35 @@ interface types {
     ///    computed hash.
     ///
     /// However, none of these is required.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     metadata-hash: async func() -> result<metadata-hash-value, error-code>;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a directory descriptor and a relative path.
     ///
     /// This performs the same hash computation as `metadata-hash`.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     metadata-hash-at: async func(path-flags: path-flags, path: string) -> result<metadata-hash-value, error-code>;
   }
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface preopens {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   use types.{descriptor};
 
   /// Return the set of preopened directories, and their paths.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-directories: func() -> list<tuple<descriptor, string>>;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world imports {
-  @since(version = 0.3.0-rc-2026-02-09)
-  import wasi:clocks/types@0.3.0-rc-2026-02-09;
-  @since(version = 0.3.0-rc-2026-02-09)
-  import wasi:clocks/system-clock@0.3.0-rc-2026-02-09;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
+  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  @since(version = 0.3.0-rc-2026-03-15)
+  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  @since(version = 0.3.0-rc-2026-03-15)
   import types;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import preopens;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-http-0.3.0-rc-2026-03-15/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-http-0.3.0-rc-2026-03-15/package.wit
@@ -1,13 +1,13 @@
-package wasi:http@0.3.0-rc-2026-02-09;
+package wasi:http@0.3.0-rc-2026-03-15;
 
 /// This interface defines all of the types and methods for implementing HTTP
 /// Requests and Responses, as well as their headers, trailers, and bodies.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface types {
-  use wasi:clocks/types@0.3.0-rc-2026-02-09.{duration};
+  use wasi:clocks/types@0.3.0-rc-2026-03-15.{duration};
 
   /// This type corresponds to HTTP standard Methods.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant method {
     get,
     head,
@@ -22,7 +22,7 @@ interface types {
   }
 
   /// This type corresponds to HTTP standard Related Schemes.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant scheme {
     HTTP,
     HTTPS,
@@ -30,21 +30,21 @@ interface types {
   }
 
   /// Defines the case payload type for `DNS-error` above:
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record DNS-error-payload {
     rcode: option<string>,
     info-code: option<u16>,
   }
 
   /// Defines the case payload type for `TLS-alert-received` above:
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record TLS-alert-received-payload {
     alert-id: option<u8>,
     alert-message: option<string>,
   }
 
   /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record field-size-payload {
     field-name: option<string>,
     field-size: option<u32>,
@@ -52,7 +52,7 @@ interface types {
 
   /// These cases are inspired by the IANA HTTP Proxy Error Types:
   ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),
@@ -102,7 +102,7 @@ interface types {
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant header-error {
     /// This error indicates that a `field-name` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
@@ -114,30 +114,49 @@ interface types {
     /// This error indicates that the operation on the `fields` was not
     /// permitted because the fields are immutable.
     immutable,
+    /// This error indicates that the operation would exceed an
+    /// implementation-defined limit on field sizes. This may apply to
+    /// an individual `field-value`, a single `field-name` plus all its
+    /// values, or the total aggregate size of all fields.
+    size-exceeded,
+    /// This is a catch-all error for anything that doesn't fit cleanly into a
+    /// more specific case. Implementations can use this to extend the error
+    /// type without breaking existing code. It also includes an optional
+    /// string for an unstructured description of the error. Users should not
+    /// depend on the string for diagnosing errors, as it's not required to be
+    /// consistent between implementations.
+    other(option<string>),
   }
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting fields of a `request-options` resource.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant request-options-error {
     /// Indicates the specified field is not supported by this implementation.
     not-supported,
     /// Indicates that the operation on the `request-options` was not permitted
     /// because it is immutable.
     immutable,
+    /// This is a catch-all error for anything that doesn't fit cleanly into a
+    /// more specific case. Implementations can use this to extend the error
+    /// type without breaking existing code. It also includes an optional
+    /// string for an unstructured description of the error. Users should not
+    /// depend on the string for diagnosing errors, as it's not required to be
+    /// consistent between implementations.
+    other(option<string>),
   }
 
   /// Field names are always strings.
   ///
   /// Field names should always be treated as case insensitive by the `fields`
   /// resource for the purposes of equality checking.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type field-name = string;
 
   /// Field values should always be ASCII strings. However, in
   /// reality, HTTP implementations often have to interpret malformed values,
   /// so they are provided as a list of bytes.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type field-value = list<u8>;
 
   /// This following block defines the `fields` resource which corresponds to
@@ -155,7 +174,11 @@ interface types {
   /// original casing used to construct or mutate the `fields` resource. The `fields`
   /// resource should use that original casing when serializing the fields for
   /// transport or when returning them from a method.
-  @since(version = 0.3.0-rc-2026-02-09)
+  ///
+  /// Implementations may impose limits on individual field values and on total
+  /// aggregate field section size. Operations that would exceed these limits
+  /// fail with `header-error.size-exceeded`
+  @since(version = 0.3.0-rc-2026-03-15)
   resource fields {
     /// Construct an empty HTTP Fields.
     ///
@@ -175,7 +198,8 @@ interface types {
     /// well-formed, so they are represented as a raw list of bytes.
     ///
     /// An error result will be returned if any header or value was
-    /// syntactically invalid, or if a header was forbidden.
+    /// syntactically invalid, if a header was forbidden, or if the
+    /// entries would exceed an implementation size limit.
     from-list: static func(entries: list<tuple<field-name, field-value>>) -> result<fields, header-error>;
     /// Get all of the values corresponding to a name. If the name is not present
     /// in this `fields`, an empty list is returned. However, if the name is
@@ -189,6 +213,9 @@ interface types {
     /// name, if they have been set.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
+    ///
+    /// Fails with `header-error.size-exceeded` if the name or values would
+    /// exceed an implementation-defined size limit.
     set: func(name: field-name, value: list<field-value>) -> result<_, header-error>;
     /// Delete all values for a name. Does nothing if no values for the name
     /// exist.
@@ -206,6 +233,9 @@ interface types {
     /// values for that name.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
+    ///
+    /// Fails with `header-error.size-exceeded` if the value would exceed
+    /// an implementation-defined size limit.
     append: func(name: field-name, value: field-value) -> result<_, header-error>;
     /// Retrieve the full set of names and values in the Fields. Like the
     /// constructor, the list represents each name-value pair.
@@ -224,15 +254,15 @@ interface types {
   }
 
   /// Headers is an alias for Fields.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type headers = fields;
 
   /// Trailers is an alias for Fields.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type trailers = fields;
 
   /// Represents an HTTP Request.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource request {
     /// Construct a new `request` with a default `method` of `GET`, and
     /// `none` values for `path-with-query`, `scheme`, and `authority`.
@@ -319,7 +349,7 @@ interface types {
   ///
   /// These timeouts are separate from any the user may use to bound an
   /// asynchronous call.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource request-options {
     /// Construct a default `request-options` value.
     constructor();
@@ -348,11 +378,11 @@ interface types {
   }
 
   /// This type corresponds to the HTTP standard Status Code.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type status-code = u16;
 
   /// Represents an HTTP Response.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource response {
     /// Construct a new `response`, with a default `status-code` of `200`.
     /// If a different `status-code` is needed, it must be set via the
@@ -401,7 +431,7 @@ interface types {
 ///
 /// In `wasi:http/middleware` this interface is both exported and imported as
 /// the "downstream" and "upstream" directions of the middleware chain.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface handler {
   use types.{request, response, error-code};
 
@@ -420,7 +450,7 @@ interface handler {
 /// (including WIT itself) is unable to represent a component importing two
 /// instances of the same interface. A `client.send` import may be linked
 /// directly to a `handler.handle` export to bypass the network.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface client {
   use types.{request, response, error-code};
 
@@ -432,22 +462,22 @@ interface client {
 /// The `wasi:http/service` world captures a broad category of HTTP services
 /// including web applications, API servers, and proxies. It may be `include`d
 /// in more specific worlds such as `wasi:http/middleware`.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world service {
-  import wasi:cli/types@0.3.0-rc-2026-02-09;
-  import wasi:cli/stdout@0.3.0-rc-2026-02-09;
-  import wasi:cli/stderr@0.3.0-rc-2026-02-09;
-  import wasi:cli/stdin@0.3.0-rc-2026-02-09;
-  import wasi:clocks/types@0.3.0-rc-2026-02-09;
+  import wasi:cli/types@0.3.0-rc-2026-03-15;
+  import wasi:cli/stdout@0.3.0-rc-2026-03-15;
+  import wasi:cli/stderr@0.3.0-rc-2026-03-15;
+  import wasi:cli/stdin@0.3.0-rc-2026-03-15;
+  import wasi:clocks/types@0.3.0-rc-2026-03-15;
   import types;
   import client;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-02-09;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-02-09;
+  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-02-09;
-  import wasi:random/random@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-02-09;
+  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
+  import wasi:random/random@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
 
   export handler;
 }
@@ -457,23 +487,23 @@ world service {
 /// Components may implement this world to allow them to participate in handler
 /// "chains" where a `request` flows through handlers on its way to some terminal
 /// `service` and corresponding `response` flows in the opposite direction.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world middleware {
-  import wasi:clocks/types@0.3.0-rc-2026-02-09;
+  import wasi:clocks/types@0.3.0-rc-2026-03-15;
   import types;
   import handler;
-  import wasi:cli/types@0.3.0-rc-2026-02-09;
-  import wasi:cli/stdout@0.3.0-rc-2026-02-09;
-  import wasi:cli/stderr@0.3.0-rc-2026-02-09;
-  import wasi:cli/stdin@0.3.0-rc-2026-02-09;
+  import wasi:cli/types@0.3.0-rc-2026-03-15;
+  import wasi:cli/stdout@0.3.0-rc-2026-03-15;
+  import wasi:cli/stderr@0.3.0-rc-2026-03-15;
+  import wasi:cli/stdin@0.3.0-rc-2026-03-15;
   import client;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-02-09;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-02-09;
+  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-02-09;
-  import wasi:random/random@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure@0.3.0-rc-2026-02-09;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-02-09;
+  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
+  import wasi:random/random@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure@0.3.0-rc-2026-03-15;
+  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
 
   export handler;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-random-0.3.0-rc-2026-03-15/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-random-0.3.0-rc-2026-03-15/package.wit
@@ -1,10 +1,10 @@
-package wasi:random@0.3.0-rc-2026-02-09;
+package wasi:random@0.3.0-rc-2026-03-15;
 
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface insecure-seed {
   /// Return a 128-bit value that may contain a pseudo-random value.
   ///
@@ -23,7 +23,7 @@ interface insecure-seed {
   /// This will likely be changed to a value import, to prevent it from being
   /// called multiple times and potentially used for purposes other than DoS
   /// protection.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-insecure-seed: func() -> tuple<u64, u64>;
 }
 
@@ -31,9 +31,9 @@ interface insecure-seed {
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface insecure {
-  /// Return `len` insecure pseudo-random bytes.
+  /// Return up to `max-len` insecure pseudo-random bytes.
   ///
   /// This function is not cryptographically secure. Do not use it for
   /// anything related to security.
@@ -41,14 +41,21 @@ interface insecure {
   /// There are no requirements on the values of the returned bytes, however
   /// implementations are encouraged to return evenly distributed values with
   /// a long period.
-  @since(version = 0.3.0-rc-2026-02-09)
-  get-insecure-random-bytes: func(len: u64) -> list<u8>;
+  ///
+  /// Implementations MAY return fewer bytes than requested (a short read).
+  /// Callers that require exactly `max-len` bytes MUST call this function in
+  /// a loop until the desired number of bytes has been accumulated.
+  /// Implementations MUST return at least 1 byte when `max-len` is greater
+  /// than zero. When `max-len` is zero, implementations MUST return an empty
+  /// list without trapping.
+  @since(version = 0.3.0-rc-2026-03-15)
+  get-insecure-random-bytes: func(max-len: u64) -> list<u8>;
 
   /// Return an insecure pseudo-random `u64` value.
   ///
   /// This function returns the same type of pseudo-random data as
   /// `get-insecure-random-bytes`, represented as a `u64`.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-insecure-random-u64: func() -> u64;
 }
 
@@ -56,9 +63,10 @@ interface insecure {
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface random {
-  /// Return `len` cryptographically-secure random or pseudo-random bytes.
+  /// Return up to `max-len` cryptographically-secure random or pseudo-random
+  /// bytes.
   ///
   /// This function must produce data at least as cryptographically secure and
   /// fast as an adequately seeded cryptographically-secure pseudo-random
@@ -67,26 +75,33 @@ interface random {
   /// request and on requests for numbers of bytes. The returned data must
   /// always be unpredictable.
   ///
+  /// Implementations MAY return fewer bytes than requested (a short read).
+  /// Callers that require exactly `max-len` bytes MUST call this function in
+  /// a loop until the desired number of bytes has been accumulated.
+  /// Implementations MUST return at least 1 byte when `max-len` is greater
+  /// than zero. When `max-len` is zero, implementations MUST return an empty
+  /// list without trapping.
+  ///
   /// This function must always return fresh data. Deterministic environments
   /// must omit this function, rather than implementing it with deterministic
   /// data.
-  @since(version = 0.3.0-rc-2026-02-09)
-  get-random-bytes: func(len: u64) -> list<u8>;
+  @since(version = 0.3.0-rc-2026-03-15)
+  get-random-bytes: func(max-len: u64) -> list<u8>;
 
   /// Return a cryptographically-secure random or pseudo-random `u64` value.
   ///
   /// This function returns the same type of data as `get-random-bytes`,
   /// represented as a `u64`.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   get-random-u64: func() -> u64;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world imports {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import random;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import insecure;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import insecure-seed;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-sockets-0.3.0-rc-2026-03-15/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-sockets-0.3.0-rc-2026-03-15/package.wit
@@ -1,63 +1,86 @@
-package wasi:sockets@0.3.0-rc-2026-02-09;
+package wasi:sockets@0.3.0-rc-2026-03-15;
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface types {
-  @since(version = 0.3.0-rc-2026-02-09)
-  use wasi:clocks/types@0.3.0-rc-2026-02-09.{duration};
+  @since(version = 0.3.0-rc-2026-03-15)
+  use wasi:clocks/types@0.3.0-rc-2026-03-15.{duration};
 
   /// Error codes.
   ///
   /// In theory, every API can return any error code.
   /// In practice, API's typically only return the errors documented per API
   /// combined with a couple of errors that are always possible:
-  /// - `unknown`
+  /// - `other`
   /// - `access-denied`
   /// - `not-supported`
   /// - `out-of-memory`
   ///
   /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
-  @since(version = 0.3.0-rc-2026-02-09)
-  enum error-code {
-    /// Unknown error
-    unknown,
+  @since(version = 0.3.0-rc-2026-03-15)
+  variant error-code {
     /// Access denied.
     ///
     /// POSIX equivalent: EACCES, EPERM
     access-denied,
     /// The operation is not supported.
     ///
-    /// POSIX equivalent: EOPNOTSUPP
+    /// POSIX equivalent: EOPNOTSUPP, ENOPROTOOPT, EPFNOSUPPORT, EPROTONOSUPPORT, ESOCKTNOSUPPORT
     not-supported,
     /// One of the arguments is invalid.
     ///
-    /// POSIX equivalent: EINVAL
+    /// POSIX equivalent: EINVAL, EDESTADDRREQ, EAFNOSUPPORT
     invalid-argument,
     /// Not enough memory to complete the operation.
     ///
-    /// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+    /// POSIX equivalent: ENOMEM, ENOBUFS
     out-of-memory,
     /// The operation timed out before it could finish completely.
+    ///
+    /// POSIX equivalent: ETIMEDOUT
     timeout,
     /// The operation is not valid in the socket's current state.
     invalid-state,
-    /// A bind operation failed because the provided address is not an address that the `network` can bind to.
+    /// The local address is not available.
+    ///
+    /// POSIX equivalent: EADDRNOTAVAIL
     address-not-bindable,
-    /// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+    /// A bind operation failed because the provided address is already in
+    /// use or because there are no ephemeral ports available.
+    ///
+    /// POSIX equivalent: EADDRINUSE
     address-in-use,
-    /// The remote address is not reachable
+    /// The remote address is not reachable.
+    ///
+    /// POSIX equivalent: EHOSTUNREACH, EHOSTDOWN, ENETDOWN, ENETUNREACH, ENONET
     remote-unreachable,
-    /// The TCP connection was forcefully rejected
+    /// The connection was forcefully rejected.
+    ///
+    /// POSIX equivalent: ECONNREFUSED
     connection-refused,
-    /// The TCP connection was reset.
+    /// A write failed because the connection was broken.
+    ///
+    /// POSIX equivalent: EPIPE
+    connection-broken,
+    /// The connection was reset.
+    ///
+    /// POSIX equivalent: ECONNRESET
     connection-reset,
-    /// A TCP connection was aborted.
+    /// The connection was aborted.
+    ///
+    /// POSIX equivalent: ECONNABORTED
     connection-aborted,
     /// The size of a datagram sent to a UDP socket exceeded the maximum
     /// supported size.
+    ///
+    /// POSIX equivalent: EMSGSIZE
     datagram-too-large,
+    /// A catch-all for errors not captured by the existing variants.
+    /// Implementations can use this to extend the error type without
+    /// breaking existing code.
+    other(option<string>),
   }
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   enum ip-address-family {
     /// Similar to `AF_INET` in POSIX.
     ipv4,
@@ -65,19 +88,19 @@ interface types {
     ipv6,
   }
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type ipv4-address = tuple<u8, u8, u8, u8>;
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant ip-address {
     ipv4(ipv4-address),
     ipv6(ipv6-address),
   }
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record ipv4-socket-address {
     /// sin_port
     port: u16,
@@ -85,7 +108,7 @@ interface types {
     address: ipv4-address,
   }
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   record ipv6-socket-address {
     /// sin6_port
     port: u16,
@@ -97,7 +120,7 @@ interface types {
     scope-id: u32,
   }
 
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   variant ip-socket-address {
     ipv4(ipv4-socket-address),
     ipv6(ipv6-socket-address),
@@ -112,39 +135,57 @@ interface types {
   /// - `connecting`
   /// - `connected`
   /// - `closed`
-  /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics-0.3.0-draft.md>
+  /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics-0.3.0-draft.md>
   /// for more information.
   ///
   /// Note: Except where explicitly mentioned, whenever this documentation uses
   /// the term "bound" without backticks it actually means: in the `bound` state *or higher*.
   /// (i.e. `bound`, `listening`, `connecting` or `connected`)
   ///
+  /// WASI uses shared ownership semantics: the `tcp-socket` handle and all
+  /// derived `stream` and `future` values reference a single underlying OS
+  /// socket:
+  /// - Send/receive streams remain functional after the original `tcp-socket`
+  ///   handle is dropped.
+  /// - The stream returned by `listen` behaves similarly.
+  /// - Client sockets returned by `tcp-socket::listen` are independent and do
+  ///   not keep the listening socket alive.
+  ///
+  /// The OS socket is closed only after the last handle is dropped. This
+  /// model has observable effects; for example, it affects when the local
+  /// port binding is released.
+  ///
   /// In addition to the general error codes documented on the
   /// `types::error-code` type, TCP socket methods may always return
   /// `error(invalid-state)` when in the `closed` state.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource tcp-socket {
     /// Create a new TCP socket.
     ///
-    /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
-    /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)`
+    /// in POSIX. On IPv6 sockets, IPV6_V6ONLY is enabled by default and
+    /// can't be configured otherwise.
     ///
     /// Unlike POSIX, WASI sockets have no notion of a socket-level
     /// `O_NONBLOCK` flag. Instead they fully rely on the Component Model's
     /// async support.
+    ///
+    /// # Typical errors
+    /// - `not-supported`: The `address-family` is not supported. (EAFNOSUPPORT)
     ///
     /// # References
     /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     create: static func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
     /// Bind the socket to the provided IP address and port.
     ///
-    /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-    /// network interface(s) to bind to.
-    /// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+    /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is
+    /// left to the implementation to decide which network interface(s) to
+    /// bind to. If the TCP/UDP port is zero, the socket will be bound to a
+    /// random free port.
     ///
     /// Bind can be attempted multiple times on the same socket, even with
     /// different arguments on each iteration. But never concurrently and
@@ -161,21 +202,27 @@ interface types {
     /// - `address-not-bindable`:      `local-address` is not an address that can be bound to. (EADDRNOTAVAIL)
     ///
     /// # Implementors note
-    /// When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
-    /// state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR
-    /// socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
-    /// and SO_REUSEADDR performs something different entirely.
+    /// The bind operation shouldn't be affected by the TIME_WAIT state of a
+    /// recently closed socket on the same local address. In practice this
+    /// means that the SO_REUSEADDR socket option should be set implicitly
+    /// on all platforms, except on Windows where this is the default
+    /// behavior and SO_REUSEADDR performs something different.
     ///
     /// # References
     /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     bind: func(local-address: ip-socket-address) -> result<_, error-code>;
     /// Connect to a remote endpoint.
     ///
-    /// On success, the socket is transitioned into the `connected` state and this function returns a connection resource.
+    /// On success, the socket is transitioned into the `connected` state
+    /// and the `remote-address` of the socket is updated.
+    /// The `local-address` may be updated as well, based on the best network
+    /// path to `remote-address`. If the socket was not already explicitly
+    /// bound, this function will implicitly bind the socket to a random
+    /// free port.
     ///
     /// After a failed connection attempt, the socket will be in the `closed`
     /// state and the only valid action left is to `drop` the socket. A single
@@ -202,7 +249,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
     /// Start listening and return a stream of new inbound connections.
     ///
@@ -274,7 +321,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     listen: func() -> result<stream<tcp-socket>, error-code>;
     /// Transmit data to peer.
     ///
@@ -288,6 +335,8 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-state`:             The socket is not in the `connected` state. (ENOTCONN)
+    /// - `invalid-state`:             `send` has already been called on this socket.
+    /// - `connection-broken`:         The connection is not writable anymore. (EPIPE, ECONNABORTED on Windows)
     /// - `connection-reset`:          The connection was reset. (ECONNRESET)
     /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
     ///
@@ -296,31 +345,27 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/send.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     send: func(data: stream<u8>) -> future<result<_, error-code>>;
     /// Read data from peer.
     ///
-    /// This function returns a `stream` which provides the data received from the
-    /// socket, and a `future` providing additional error information in case the
-    /// socket is closed abnormally.
+    /// Returns a `stream` of data sent by the peer. The implementation
+    /// drops the stream once no more data is available. At that point, the
+    /// returned `future` resolves to:
+    /// - `ok` after a graceful shutdown from the peer (i.e. a FIN packet), or
+    /// - `err` if the socket was closed abnormally.
     ///
-    /// If the socket is closed normally, `stream.read` on the `stream` will return
-    /// `read-status::closed` with no `error-context` and the future resolves to
-    /// the value `ok`. If the socket is closed abnormally, `stream.read` on the
-    /// `stream` returns `read-status::closed` with an `error-context` and the future
-    /// resolves to `err` with an `error-code`.
+    /// `receive` may be called only once per socket. Subsequent calls return
+    /// a closed stream and a future resolved to `err(invalid-state)`.
     ///
-    /// `receive` is meant to be called only once per socket. If it is called more
-    /// than once, the subsequent calls return a new `stream` that fails as if it
-    /// were closed abnormally.
-    ///
-    /// If the caller is not expecting to receive any data from the peer,
-    /// they may drop the stream. Any data still in the receive queue
+    /// If the caller is not expecting to receive any more data from the peer,
+    /// they should drop the stream. Any data still in the receive queue
     /// will be discarded. This is equivalent to calling `shutdown(SHUT_RD)`
     /// in POSIX.
     ///
     /// # Typical errors
     /// - `invalid-state`:             The socket is not in the `connected` state. (ENOTCONN)
+    /// - `invalid-state`:             `receive` has already been called on this socket.
     /// - `connection-reset`:          The connection was reset. (ECONNRESET)
     /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
     ///
@@ -329,7 +374,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     receive: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
     /// Get the bound local address.
     ///
@@ -337,7 +382,8 @@ interface types {
     /// > If the socket has not been bound to a local name, the value
     /// > stored in the object pointed to by `address` is unspecified.
     ///
-    /// WASI is stricter and requires `get-local-address` to return `invalid-state` when the socket hasn't been bound yet.
+    /// WASI is stricter and requires `get-local-address` to return
+    /// `invalid-state` when the socket hasn't been bound yet.
     ///
     /// # Typical errors
     /// - `invalid-state`: The socket is not bound to any local address.
@@ -347,7 +393,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-local-address: func() -> result<ip-socket-address, error-code>;
     /// Get the remote address.
     ///
@@ -359,30 +405,32 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-remote-address: func() -> result<ip-socket-address, error-code>;
     /// Whether the socket is in the `listening` state.
     ///
     /// Equivalent to the SO_ACCEPTCONN socket option.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-is-listening: func() -> bool;
     /// Whether this is a IPv4 or IPv6 socket.
     ///
     /// This is the value passed to the constructor.
     ///
     /// Equivalent to the SO_DOMAIN socket option.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-address-family: func() -> ip-address-family;
-    /// Hints the desired listen queue size. Implementations are free to ignore this.
+    /// Hints the desired listen queue size. Implementations are free to
+    /// ignore this.
     ///
     /// If the provided value is 0, an `invalid-argument` error is returned.
-    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    /// Any other value will never cause an error, but it might be silently
+    /// clamped and/or rounded.
     ///
     /// # Typical errors
     /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
     /// - `invalid-argument`:     (set) The provided value was 0.
     /// - `invalid-state`:        (set) The socket is in the `connecting` or `connected` state.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
     /// Enables or disables keepalive.
     ///
@@ -390,54 +438,60 @@ interface types {
     /// - `keep-alive-idle-time`
     /// - `keep-alive-interval`
     /// - `keep-alive-count`
-    /// These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
+    /// These properties can be configured while `keep-alive-enabled` is
+    /// false, but only come into effect when `keep-alive-enabled` is true.
     ///
     /// Equivalent to the SO_KEEPALIVE socket option.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-keep-alive-enabled: func() -> result<bool, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-keep-alive-enabled: func(value: bool) -> result<_, error-code>;
-    /// Amount of time the connection has to be idle before TCP starts sending keepalive packets.
+    /// Amount of time the connection has to be idle before TCP starts
+    /// sending keepalive packets.
     ///
     /// If the provided value is 0, an `invalid-argument` error is returned.
-    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
-    /// I.e. after setting a value, reading the same setting back may return a different value.
+    /// All other values are accepted without error, but may be
+    /// clamped or rounded. As a result, the value read back from
+    /// this setting may differ from the value that was set.
     ///
     /// Equivalent to the TCP_KEEPIDLE socket option. (TCP_KEEPALIVE on MacOS)
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-keep-alive-idle-time: func() -> result<duration, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-keep-alive-idle-time: func(value: duration) -> result<_, error-code>;
     /// The time between keepalive packets.
     ///
     /// If the provided value is 0, an `invalid-argument` error is returned.
-    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
-    /// I.e. after setting a value, reading the same setting back may return a different value.
+    /// All other values are accepted without error, but may be
+    /// clamped or rounded. As a result, the value read back from
+    /// this setting may differ from the value that was set.
     ///
     /// Equivalent to the TCP_KEEPINTVL socket option.
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-keep-alive-interval: func() -> result<duration, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-keep-alive-interval: func(value: duration) -> result<_, error-code>;
-    /// The maximum amount of keepalive packets TCP should send before aborting the connection.
+    /// The maximum amount of keepalive packets TCP should send before
+    /// aborting the connection.
     ///
     /// If the provided value is 0, an `invalid-argument` error is returned.
-    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
-    /// I.e. after setting a value, reading the same setting back may return a different value.
+    /// All other values are accepted without error, but may be
+    /// clamped or rounded. As a result, the value read back from
+    /// this setting may differ from the value that was set.
     ///
     /// Equivalent to the TCP_KEEPCNT socket option.
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-keep-alive-count: func() -> result<u32, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-keep-alive-count: func(value: u32) -> result<_, error-code>;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     ///
@@ -445,37 +499,49 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-hop-limit: func() -> result<u8, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-hop-limit: func(value: u8) -> result<_, error-code>;
-    /// The kernel buffer space reserved for sends/receives on this socket.
+    /// Kernel buffer space reserved for sending/receiving on this socket.
+    /// Implementations usually treat this as a cap the buffer can grow to,
+    /// rather than allocating the full amount immediately.
     ///
     /// If the provided value is 0, an `invalid-argument` error is returned.
-    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
-    /// I.e. after setting a value, reading the same setting back may return a different value.
+    /// All other values are accepted without error, but may be
+    /// clamped or rounded. As a result, the value read back from
+    /// this setting may differ from the value that was set.
+    ///
+    /// This is only a performance hint. The implementation may ignore it or
+    /// tweak it based on real traffic patterns.
+    /// Linux and macOS appear to behave differently depending on whether a
+    /// buffer size was explicitly set. When set, they tend to honor it; when
+    /// not set, they dynamically adjust the buffer size as the connection
+    /// progresses. This is especially noticeable when comparing the values
+    /// from before and after connection establishment.
     ///
     /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-receive-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-send-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-send-buffer-size: func(value: u64) -> result<_, error-code>;
   }
 
   /// A UDP socket handle.
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resource udp-socket {
     /// Create a new UDP socket.
     ///
-    /// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
-    /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)`
+    /// in POSIX. On IPv6 sockets, IPV6_V6ONLY is enabled by default and
+    /// can't be configured otherwise.
     ///
     /// Unlike POSIX, WASI sockets have no notion of a socket-level
     /// `O_NONBLOCK` flag. Instead they fully rely on the Component Model's
@@ -486,13 +552,14 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     create: static func(address-family: ip-address-family) -> result<udp-socket, error-code>;
     /// Bind the socket to the provided IP address and port.
     ///
-    /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-    /// network interface(s) to bind to.
-    /// If the port is zero, the socket will be bound to a random free port.
+    /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is
+    /// left to the implementation to decide which network interface(s) to
+    /// bind to. If the port is zero, the socket will be bound to a random
+    /// free port.
     ///
     /// # Typical errors
     /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
@@ -506,7 +573,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     bind: func(local-address: ip-socket-address) -> result<_, error-code>;
     /// Associate this socket with a specific peer address.
     ///
@@ -544,12 +611,12 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     connect: func(remote-address: ip-socket-address) -> result<_, error-code>;
     /// Dissociate this socket from its peer address.
     ///
     /// After calling this method, `send` & `receive` are free to communicate
-    /// with any address again.
+    /// with any remote address again.
     ///
     /// The POSIX equivalent of this is calling `connect` with an `AF_UNSPEC` address.
     ///
@@ -561,7 +628,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     disconnect: func() -> result<_, error-code>;
     /// Send a message on the socket to a particular peer.
     ///
@@ -572,6 +639,9 @@ interface types {
     /// Additionally, if the socket is connected, a `remote-address` argument
     /// _may_ be provided but then it must be identical to the address
     /// passed to `connect`.
+    ///
+    /// If the socket has not been explicitly bound, it will be
+    /// implicitly bound to a random free port.
     ///
     /// Implementations may trap if the `data` length exceeds 64 KiB.
     ///
@@ -584,6 +654,14 @@ interface types {
     /// - `remote-unreachable`:      The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
     /// - `connection-refused`:      The connection was refused. (ECONNREFUSED)
     /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+    /// - `address-in-use`:          Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+    ///
+    /// # Implementors note
+    /// WASI requires `send` to perform an implicit bind if the socket
+    /// has not been bound. Not all platforms (notably Windows) exhibit
+    /// this behavior natively. On such platforms, the WASI implementation
+    /// should emulate it by performing the bind if the guest has not
+    /// already done so.
     ///
     /// # References
     /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
@@ -594,7 +672,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     send: async func(data: list<u8>, remote-address: option<ip-socket-address>) -> result<_, error-code>;
     /// Receive a message on the socket.
     ///
@@ -619,7 +697,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_wsarecvmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     receive: async func() -> result<tuple<list<u8>, ip-socket-address>, error-code>;
     /// Get the current bound address.
     ///
@@ -627,7 +705,8 @@ interface types {
     /// > If the socket has not been bound to a local name, the value
     /// > stored in the object pointed to by `address` is unspecified.
     ///
-    /// WASI is stricter and requires `get-local-address` to return `invalid-state` when the socket hasn't been bound yet.
+    /// WASI is stricter and requires `get-local-address` to return
+    /// `invalid-state` when the socket hasn't been bound yet.
     ///
     /// # Typical errors
     /// - `invalid-state`: The socket is not bound to any local address.
@@ -637,7 +716,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-local-address: func() -> result<ip-socket-address, error-code>;
     /// Get the address the socket is currently "connected" to.
     ///
@@ -649,14 +728,14 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-remote-address: func() -> result<ip-socket-address, error-code>;
     /// Whether this is a IPv4 or IPv6 socket.
     ///
     /// This is the value passed to the constructor.
     ///
     /// Equivalent to the SO_DOMAIN socket option.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-address-family: func() -> ip-address-family;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     ///
@@ -664,41 +743,42 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-unicast-hop-limit: func() -> result<u8, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
-    /// The kernel buffer space reserved for sends/receives on this socket.
+    /// Kernel buffer space reserved for sending/receiving on this socket.
+    /// Implementations usually treat this as a cap the buffer can grow to,
+    /// rather than allocating the full amount immediately.
     ///
     /// If the provided value is 0, an `invalid-argument` error is returned.
-    /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
-    /// I.e. after setting a value, reading the same setting back may return a different value.
+    /// All other values are accepted without error, but may be
+    /// clamped or rounded. As a result, the value read back from
+    /// this setting may differ from the value that was set.
     ///
     /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-receive-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     get-send-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-02-09)
+    @since(version = 0.3.0-rc-2026-03-15)
     set-send-buffer-size: func(value: u64) -> result<_, error-code>;
   }
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 interface ip-name-lookup {
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   use types.{ip-address};
 
   /// Lookup error codes.
-  @since(version = 0.3.0-rc-2026-02-09)
-  enum error-code {
-    /// Unknown error
-    unknown,
+  @since(version = 0.3.0-rc-2026-03-15)
+  variant error-code {
     /// Access denied.
     ///
     /// POSIX equivalent: EACCES, EPERM
@@ -719,13 +799,17 @@ interface ip-name-lookup {
     ///
     /// POSIX equivalent: EAI_FAIL
     permanent-resolver-failure,
+    /// A catch-all for errors not captured by the existing variants.
+    /// Implementations can use this to extend the error type without
+    /// breaking existing code.
+    other(option<string>),
   }
 
   /// Resolve an internet host name to a list of IP addresses.
   ///
-  /// Unicode domain names are automatically converted to ASCII using IDNA encoding.
-  /// If the input is an IP address string, the address is parsed and returned
-  /// as-is without making any external requests.
+  /// Unicode domain names are automatically converted to ASCII using IDNA
+  /// encoding. If the input is an IP address string, the address is parsed
+  /// and returned as-is without making any external requests.
   ///
   /// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
   ///
@@ -735,24 +819,21 @@ interface ip-name-lookup {
   /// with at least one address. Additionally, this function never returns
   /// IPv4-mapped IPv6 addresses.
   ///
-  /// The returned future will resolve to an error code in case of failure.
-  /// It will resolve to success once the returned stream is exhausted.
-  ///
   /// # References:
   /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
   /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
   /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
   /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   resolve-addresses: async func(name: string) -> result<list<ip-address>, error-code>;
 }
 
-@since(version = 0.3.0-rc-2026-02-09)
+@since(version = 0.3.0-rc-2026-03-15)
 world imports {
-  @since(version = 0.3.0-rc-2026-02-09)
-  import wasi:clocks/types@0.3.0-rc-2026-02-09;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
+  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  @since(version = 0.3.0-rc-2026-03-15)
   import types;
-  @since(version = 0.3.0-rc-2026-02-09)
+  @since(version = 0.3.0-rc-2026-03-15)
   import ip-name-lookup;
 }

--- a/tests/rust/wasm32-wasip3/wit/wasi.wit
+++ b/tests/rust/wasm32-wasip3/wit/wasi.wit
@@ -1,10 +1,10 @@
 package test:wasip3;
 
 world wasip3 {
-    include wasi:cli/command@0.3.0-rc-2026-02-09;
-    include wasi:clocks/imports@0.3.0-rc-2026-02-09;
-    include wasi:filesystem/imports@0.3.0-rc-2026-02-09;
-    include wasi:http/middleware@0.3.0-rc-2026-02-09;
-    include wasi:random/imports@0.3.0-rc-2026-02-09;
-    include wasi:sockets/imports@0.3.0-rc-2026-02-09;
+    include wasi:cli/command@0.3.0-rc-2026-03-15;
+    include wasi:clocks/imports@0.3.0-rc-2026-03-15;
+    include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
+    include wasi:http/middleware@0.3.0-rc-2026-03-15;
+    include wasi:random/imports@0.3.0-rc-2026-03-15;
+    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
 }

--- a/tests/rust/wasm32-wasip3/wkg.lock
+++ b/tests/rust/wasm32-wasip3/wkg.lock
@@ -7,51 +7,51 @@ name = "wasi:cli"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-02-09"
-version = "0.3.0-rc-2026-02-09"
-digest = "sha256:d3f07fc00d81731517b50f4a9dca08168e299e856d4931246c8c54e028cec2ff"
+requirement = "=0.3.0-rc-2026-03-15"
+version = "0.3.0-rc-2026-03-15"
+digest = "sha256:104654cfcb218c34c21ea06ab95f0d6811508643e9692bb3db751cde5640365f"
 
 [[packages]]
 name = "wasi:clocks"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-02-09"
-version = "0.3.0-rc-2026-02-09"
-digest = "sha256:419ee877c995ea7c3beb8c5068ca7bc38fe93584a8b4a4d4ac387b8196f0a88c"
+requirement = "=0.3.0-rc-2026-03-15"
+version = "0.3.0-rc-2026-03-15"
+digest = "sha256:10f8b2f42c5f8a731292977064788cbb8ca9164c83ae7f4a295565e7b926a313"
 
 [[packages]]
 name = "wasi:filesystem"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-02-09"
-version = "0.3.0-rc-2026-02-09"
-digest = "sha256:f8f503cf9547915272660d452ddc23cf965cdbf64aad0b68975d07b1da2637ac"
+requirement = "=0.3.0-rc-2026-03-15"
+version = "0.3.0-rc-2026-03-15"
+digest = "sha256:d8e683409e17bbe06ce6560b67dc19414e6b21f62e88f22ca436f8967dfde188"
 
 [[packages]]
 name = "wasi:http"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-02-09"
-version = "0.3.0-rc-2026-02-09"
-digest = "sha256:e47b9f1ac046656177dc0a57f5db00e3f9a4a4060450f76f56d93cd2844e94e6"
+requirement = "=0.3.0-rc-2026-03-15"
+version = "0.3.0-rc-2026-03-15"
+digest = "sha256:ed996ba07af24b216deb3d59bf56362f443d8bcfd1b07d1bfd80c49cb37df399"
 
 [[packages]]
 name = "wasi:random"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-02-09"
-version = "0.3.0-rc-2026-02-09"
-digest = "sha256:2262570bf958a5c3c29fac590720a27527eaa509d1ca6ec5b5e48d937325b538"
+requirement = "=0.3.0-rc-2026-03-15"
+version = "0.3.0-rc-2026-03-15"
+digest = "sha256:821a5c015d3833f748fb00f2279d4fccc360d38f204f37f7ae2af904fc1f7f13"
 
 [[packages]]
 name = "wasi:sockets"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-02-09"
-version = "0.3.0-rc-2026-02-09"
-digest = "sha256:d5ab258fb7307ec53859c79ca379801c317cbfcc6b235dfcc59282f90dd0c9a0"
+requirement = "=0.3.0-rc-2026-03-15"
+version = "0.3.0-rc-2026-03-15"
+digest = "sha256:9944ecbee9950744290bb1ccb134aa2fc9821307fd6016cb01e6d617bc382cfe"


### PR DESCRIPTION
Bump all WIT packages to latest rc.

Note this was all a mechanical rev. There are API changes between the two rc's, but we did not hit those cases in tests.