### PR TITLE
Remove buffer size assertions

### DIFF
--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-listen.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-listen.rs
@@ -46,11 +46,6 @@ async fn test_inherited_properties(family: IpAddressFamily) {
             );
             assert_eq!(next.get_keep_alive_count(), sock.get_keep_alive_count());
             assert_eq!(next.get_hop_limit(), sock.get_hop_limit());
-            assert_eq!(
-                next.get_receive_buffer_size(),
-                sock.get_receive_buffer_size()
-            );
-            assert_eq!(next.get_send_buffer_size(), sock.get_send_buffer_size());
         },
         async {
             client.connect(local_addr).await.unwrap();


### PR DESCRIPTION
As concluded in https://github.com/bytecodealliance/wasmtime/issues/12561