### PR TITLE
feat: add initial Buck2 infra for WASI tests

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,33 @@
+[cells]
+  root = .
+  wasmono = wasmono
+  toolchains = toolchains
+  prelude = prelude
+  none = none
+
+[cell_aliases]
+  config = prelude
+  ovr_config = prelude
+  fbcode = none
+  fbsource = none
+  fbcode_macros = none
+  buck = none
+
+[external_cells]
+  prelude = bundled
+  wasmono = git
+
+[external_cell_wasmono]
+  git_origin = https://github.com/andreiltd/wasmono.git
+  commit_hash = d0a8320810aaec94af4de4d7a19ad3367f35f9af
+
+[parser]
+  target_platform_detector_spec = target:root//...->prelude//platforms:default \
+    target:prelude//...->prelude//platforms:default \
+    target:toolchains//...->prelude//platforms:default
+
+[build]
+  execution_platforms = prelude//platforms:default
+
+[project]
+  ignore = .git

--- a/.github/workflows/buck2.yml
+++ b/.github/workflows/buck2.yml
@@ -5,34 +5,46 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - '*'
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   buck2:
     name: Buck2 smoke test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    defaults:
-      run:
-        shell: bash
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Install Dotslash
+      - name: Install Buck2 helper tools
         uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
         with:
-          tool: dotslash
+          tool: dotslash,just
 
       - name: Install Rust WASI target
         run: rustup target add wasm32-wasip1
 
+      - name: Configure Buck2 launcher on Windows
+        if: runner.os == 'Windows'
+        run: echo 'BUCK2=dotslash ./buck2' >> "$GITHUB_ENV"
+
       - name: Run Starlark lint
-        run: git ls-files ':(glob)**/BUCK' ':(glob)**/*.bzl' ':(glob)**/*.bxl' | xargs dotslash ./buck2 starlark lint
+        run: just lint-starlark
 
       - name: Run Buck2 tests
-        run: dotslash ./buck2 test //tests/...
+        run: just test-all

--- a/.github/workflows/buck2.yml
+++ b/.github/workflows/buck2.yml
@@ -1,0 +1,38 @@
+name: Buck2
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  buck2:
+    name: Buck2 smoke test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Dotslash
+        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
+        with:
+          tool: dotslash
+
+      - name: Install Rust WASI target
+        run: rustup target add wasm32-wasip1
+
+      - name: Run Starlark lint
+        run: git ls-files ':(glob)**/BUCK' ':(glob)**/*.bzl' ':(glob)**/*.bxl' | xargs dotslash ./buck2 starlark lint
+
+      - name: Run Buck2 tests
+        run: dotslash ./buck2 test //tests/...

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /tests/rust/testsuite/
 /tests/assemblyscript/testsuite/
 __pycache__
+buck-out/
 
 *~
 \#*\#
-

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ Optionally you can specify test cases to skip with the `--exclude-filter` option
 ./run-tests --exclude-filter examples/skip.json
 ```
 
+### Experimental Buck2 workflow
+
+This repository also has an experimental Buck2 setup for building tests from
+source and running them through the existing test runner. The first slice covers
+C, Rust, and AssemblyScript WASI Preview 1 tests with Wasmtime:
+
+Install [Dotslash](https://dotslash-cli.com/docs/installation/) once before
+using the checked-in `./buck2` launcher, for example with `cargo install dotslash`.
+
+```bash
+./buck2 test //tests/...
+```
+
+or if you prefer using `just`
+
+``` bash
+just build
+just test
+```
+
+Buck2 fetches the WASI SDK, Node/AssemblyScript, and Wasmtime through the Buck
+toolchain graph, then uses a generic `wasi_test` rule to invoke
+`wasi_test_runner` for each Buck test target.
+
 ## Contributing
 
 Want to add a new test?  [There's a doc for that!](doc/writing-tests.md)

--- a/README.md
+++ b/README.md
@@ -86,9 +86,17 @@ using the checked-in `./buck2` launcher, for example with `cargo install dotslas
 
 or if you prefer using `just`
 
-``` bash
+```bash
 just build
 just test
+```
+
+The Buck2 lint helpers mirror the CI checks:
+
+```bash
+just lint-starlark
+just lint-cxx
+just lint-rust
 ```
 
 Buck2 fetches the WASI SDK, Node/AssemblyScript, and Wasmtime through the Buck

--- a/adapters/BUCK
+++ b/adapters/BUCK
@@ -1,0 +1,8 @@
+export_file(
+    name = "wasmtime.py",
+    src = "wasmtime.py",
+    visibility = [
+        "toolchains//...",
+        "//tests/...",
+    ],
+)

--- a/adapters/wasmtime.py
+++ b/adapters/wasmtime.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 # shlex.split() splits according to shell quoting rules
-WASMTIME = shlex.split(os.getenv("WASMTIME", "wasmtime"))
+WASMTIME = shlex.split(os.getenv("WASMTIME", "wasmtime"), posix=os.name != "nt")
 
 
 def get_name() -> str:

--- a/buck2
+++ b/buck2
@@ -1,0 +1,91 @@
+#!/usr/bin/env dotslash
+
+{
+  "name": "buck2",
+  "platforms": {
+    "macos-aarch64": {
+      "size": 33216184,
+      "hash": "blake3",
+      "digest": "b403639dd2b3a5d4f40cf76f3221abc1342e1735a55979f5f226f9e7c8bf0ff6",
+      "format": "zst",
+      "path": "buck2-aarch64-apple-darwin",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-05-18/buck2-aarch64-apple-darwin.zst"
+        }
+      ]
+    },
+    "windows-aarch64": {
+      "size": 29013413,
+      "hash": "blake3",
+      "digest": "89c77d66cf2ce1f18840d74fa9381b7a982c7d02f3c0def30041d11c3733efb3",
+      "format": "zst",
+      "path": "buck2-aarch64-pc-windows-msvc.exe",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-05-18/buck2-aarch64-pc-windows-msvc.exe.zst"
+        }
+      ]
+    },
+    "linux-aarch64": {
+      "size": 36348041,
+      "hash": "blake3",
+      "digest": "676bb82dfd7b1615679dabb3acd900918d065c8506e160e2389d17505305ddcc",
+      "format": "zst",
+      "path": "buck2-aarch64-unknown-linux-musl",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-05-18/buck2-aarch64-unknown-linux-musl.zst"
+        }
+      ]
+    },
+    "linux-riscv64": {
+      "size": 38625437,
+      "hash": "blake3",
+      "digest": "c887b97b36ac21a57a30df6728f87ba6460438b07a9cca911c343642b2738325",
+      "format": "zst",
+      "path": "buck2-riscv64gc-unknown-linux-gnu",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-05-18/buck2-riscv64gc-unknown-linux-gnu.zst"
+        }
+      ]
+    },
+    "macos-x86_64": {
+      "size": 35521124,
+      "hash": "blake3",
+      "digest": "8885a800b502eb1a669686802c4d61e5027b2871cd0c3468165c1c5d2bdf701e",
+      "format": "zst",
+      "path": "buck2-x86_64-apple-darwin",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-05-18/buck2-x86_64-apple-darwin.zst"
+        }
+      ]
+    },
+    "windows-x86_64": {
+      "size": 30584414,
+      "hash": "blake3",
+      "digest": "8792f96e21e3025815cf7971e6cb3706c9d6aebc57fcbb139836e5f60da6e357",
+      "format": "zst",
+      "path": "buck2-x86_64-pc-windows-msvc.exe",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-05-18/buck2-x86_64-pc-windows-msvc.exe.zst"
+        }
+      ]
+    },
+    "linux-x86_64": {
+      "size": 38038226,
+      "hash": "blake3",
+      "digest": "5c312eda08015d5b54aa2af1d8176ebce41a4e63ecff662737f1301ddf322e48",
+      "format": "zst",
+      "path": "buck2-x86_64-unknown-linux-musl",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-05-18/buck2-x86_64-unknown-linux-musl.zst"
+        }
+      ]
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ buck := env_var_or_default("BUCK2", "./buck2")
 
 set shell := ["bash", "-o", "pipefail", "-c"]
 
-default:
+_default:
     @just --list
 
 # Pass arbitrary arguments through to buck2.
@@ -20,6 +20,10 @@ build:
 # Run the Buck2 first-slice Wasmtime tests.
 test:
     {{buck}} test //tests:wasmtime
+
+# Run all Buck tests under //tests.
+test-all:
+    {{buck}} test //tests/...
 
 # Run one Buck test target, e.g. `just test-one //tests/c:lseek_wasmtime`.
 test-one target:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,45 @@
+buck := env_var_or_default("BUCK2", "./buck2")
+
+set shell := ["bash", "-o", "pipefail", "-c"]
+
+default:
+    @just --list
+
+# Pass arbitrary arguments through to buck2.
+buck *args:
+    {{buck}} {{args}}
+
+# List Buck targets in the repository.
+targets:
+    {{buck}} targets //...
+
+# Build all Buck targets in the repository.
+build:
+    {{buck}} build //...
+
+# Run the Buck2 first-slice Wasmtime tests.
+test:
+    {{buck}} test //tests:wasmtime
+
+# Run one Buck test target, e.g. `just test-one //tests/c:lseek_wasmtime`.
+test-one target:
+    {{buck}} test {{target}}
+
+# Run every lint recipe.
+lint: lint-starlark lint-cxx lint-rust
+
+# Run Starlark lint on Buck/Starlark/BXL files.
+lint-starlark:
+    git ls-files ':(glob)**/BUCK' ':(glob)**/*.bzl' ':(glob)**/*.bxl' | xargs {{buck}} starlark lint
+
+# Build C/C++ diagnostic subtargets and print their reports.
+lint-cxx:
+    {{buck}} bxl scripts/check.bxl:main -- --kind cxx --output check --target //... | xargs cat
+
+# Run Clippy for Rust targets and print its reports.
+lint-rust:
+    {{buck}} bxl scripts/check.bxl:main -- --kind rust --output clippy.txt --target //... | xargs cat
+
+# Remove Buck outputs.
+clean:
+    {{buck}} clean

--- a/scripts/check.bxl
+++ b/scripts/check.bxl
@@ -1,0 +1,73 @@
+# Adapted from https://github.com/dtolnay/buck2-rustc-bootstrap/blob/master/scripts/check.bxl
+#
+# Report C/C++ warnings from every dependency of the Wasmtime suite:
+#   buck2 bxl scripts/check.bxl:main -- --kind cxx --target //tests:wasmtime --output check | xargs cat
+#
+# Run clippy on every Rust dependency of the Wasmtime suite:
+#   buck2 bxl scripts/check.bxl:main -- --kind rust --target //tests:wasmtime --output clippy.txt | xargs cat
+#
+# Run checks for targets that own a specific source path:
+#   buck2 bxl scripts/check.bxl:main -- --kind rust --path tests/rust/wasm32-wasip1/src/bin/sched_yield.rs --output clippy.txt | xargs cat
+
+_KIND_REGEX = {
+    "cxx": "^(cxx_binary|cxx_library)$",
+    "rust": "^(rust_binary|rust_library)$",
+}
+
+def _collect_unconfigured_targets(ctx: bxl.Context):
+    targets = utarget_set()
+
+    for path in ctx.cli_args.path:
+        targets += ctx.uquery().owner(path)
+
+    for target in ctx.cli_args.target:
+        targets += ctx.unconfigured_targets(target)
+
+    return targets
+
+def main_impl(ctx: bxl.Context) -> None:
+    if len(ctx.cli_args.path) == 0 and len(ctx.cli_args.target) == 0:
+        fail("pass at least one --target or --path")
+
+    targets = _collect_unconfigured_targets(ctx)
+    configured_targets = ctx.configured_targets(
+        targets,
+        modifiers = ctx.cli_args.modifier,
+    )
+
+    transitive_targets = ctx.cquery().deps(configured_targets)
+    checked_targets = ctx.cquery().kind(
+        _KIND_REGEX[ctx.cli_args.kind],
+        transitive_targets,
+    )
+
+    result = ctx.build([
+        target.label.with_sub_target(ctx.cli_args.output)
+        for target in checked_targets
+    ])
+
+    if len(result) == 0:
+        fail("no {} targets matched".format(ctx.cli_args.kind))
+
+    failed_targets = []
+    for target, value in result.items():
+        if len(value.failures()) > 0:
+            failed_targets.append(target.raw_target())
+        else:
+            artifacts = ctx.output.ensure_multiple(value.artifacts())
+            ctx.output.stream(sep = "\n", wait_on = artifacts, *artifacts)
+
+    if len(failed_targets) != 0:
+        ctx.output.stream_json({"failed_targets": failed_targets})
+        fail("{} targets failed to build".format(len(failed_targets)))
+
+main = bxl.main(
+    impl = main_impl,
+    cli_args = {
+        "kind": cli_args.enum(["cxx", "rust"]),
+        "modifier": cli_args.list(cli_args.string(), short = "m", default = []),
+        "output": cli_args.string(),
+        "path": cli_args.list(cli_args.string(), default = []),
+        "target": cli_args.list(cli_args.target_expr(), default = []),
+    },
+)

--- a/test-runner/BUCK
+++ b/test-runner/BUCK
@@ -9,12 +9,13 @@ python_library(
 )
 
 remote_file(
-  name = "colorama-download",
-  url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
-  sha1 = "d6ab1608850fecfc0e1cf50bf93d743695c04027",
+    name = "colorama-download",
+    url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+    sha1 = "d6ab1608850fecfc0e1cf50bf93d743695c04027",
+    out = "colorama-0.4.6-py2.py3-none-any.whl",
 )
 
 prebuilt_python_library(
-  name = "colorama",
-  binary_src = ":colorama-download",
+    name = "colorama",
+    binary_src = ":colorama-download",
 )

--- a/test-runner/BUCK
+++ b/test-runner/BUCK
@@ -3,4 +3,18 @@ python_library(
     srcs = glob(["wasi_test_runner/**/*.py"]),
     base_module = "",
     visibility = ["//tools/..."],
+    deps = [
+        ":colorama",
+    ]
+)
+
+remote_file(
+  name = "colorama-download",
+  url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+  sha1 = "d6ab1608850fecfc0e1cf50bf93d743695c04027",
+)
+
+prebuilt_python_library(
+  name = "colorama",
+  binary_src = ":colorama-download",
 )

--- a/test-runner/BUCK
+++ b/test-runner/BUCK
@@ -1,0 +1,6 @@
+python_library(
+    name = "wasi_test_runner",
+    srcs = glob(["wasi_test_runner/**/*.py"]),
+    base_module = "",
+    visibility = ["//tools/..."],
+)

--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -11,8 +11,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, NamedTuple, Tuple, Dict, Any, IO
 
-import requests
-
 from .filters import TestFilter
 from .runtime_adapter import RuntimeAdapter
 from .test_case import (
@@ -196,6 +194,9 @@ class TestCaseRunner(TestCaseRunnerBase):
 
     def do_request(self, req: Request) -> None:
         # pylint: disable-msg=too-many-return-statements
+        # Only HTTP tests need requests; keep CLI tests runnable without it.
+        import requests  # pylint: disable=import-outside-toplevel
+
         http_server = self.get_http_server()
         if http_server is None:
             return
@@ -371,8 +372,7 @@ def _read_manifest(test_suite_path: Path) -> Manifest:
                         assert isinstance(v, str)
                         name = v
                     case "version":
-                        assert v in WasiVersion
-                        wasi_version = WasiVersion[v]
+                        wasi_version = WasiVersion(v)
                     case _:
                         raise RuntimeError(f"unexpected manifest option: {k}={v}")
 

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -1,0 +1,8 @@
+test_suite(
+    name = "wasmtime",
+    tests = [
+        "//tests/c:wasmtime",
+        "//tests/rust/wasm32-wasip1:wasmtime",
+        "//tests/assemblyscript/wasm32-wasip1:wasmtime",
+    ],
+)

--- a/tests/assemblyscript/wasm32-wasip1/BUCK
+++ b/tests/assemblyscript/wasm32-wasip1/BUCK
@@ -1,0 +1,48 @@
+load("@wasmono//:defs.bzl", "assemblyscript_binary")
+load("//tools:conformance.bzl", "wasi_suite", "wasi_test")
+
+_WASI_ASSEMBLYSCRIPT_SUITE = wasi_suite(
+    name = "WASI AssemblyScript tests [wasm32-wasip1]",
+    version = "wasm32-wasip1",
+)
+
+assemblyscript_binary(
+    name = "args_get-multiple-arguments",
+    src = "src/args_get-multiple-arguments.ts",
+    visibility = ["//tests/..."],
+)
+
+wasi_test(
+    name = "args_get-multiple-arguments_wasmtime",
+    wasm = ":args_get-multiple-arguments",
+    runtime = "toolchains//:wasmtime_runtime",
+    suite = _WASI_ASSEMBLYSCRIPT_SUITE,
+    config = "src/args_get-multiple-arguments.json",
+    labels = ["assemblyscript-wasip1"],
+    visibility = ["//tests/..."],
+)
+
+assemblyscript_binary(
+    name = "fd_write-to-stdout",
+    src = "src/fd_write-to-stdout.ts",
+    visibility = ["//tests/..."],
+)
+
+wasi_test(
+    name = "fd_write-to-stdout_wasmtime",
+    wasm = ":fd_write-to-stdout",
+    runtime = "toolchains//:wasmtime_runtime",
+    suite = _WASI_ASSEMBLYSCRIPT_SUITE,
+    config = "src/fd_write-to-stdout.json",
+    labels = ["assemblyscript-wasip1"],
+    visibility = ["//tests/..."],
+)
+
+test_suite(
+    name = "wasmtime",
+    tests = [
+        ":args_get-multiple-arguments_wasmtime",
+        ":fd_write-to-stdout_wasmtime",
+    ],
+    visibility = ["//tests/..."],
+)

--- a/tests/c/BUCK
+++ b/tests/c/BUCK
@@ -1,0 +1,51 @@
+load("//tools:conformance.bzl", "wasi_suite", "wasi_test")
+
+_WASI_C_SUITE = wasi_suite(
+    name = "WASI C tests [wasm32-wasip1]",
+    version = "wasm32-wasip1",
+)
+
+cxx_binary(
+    name = "clock_getres-monotonic",
+    srcs = ["src/clock_getres-monotonic.c"],
+    _cxx_toolchain = "toolchains//:cxx_wasi_p1",
+    visibility = ["//tests/..."],
+)
+
+wasi_test(
+    name = "clock_getres-monotonic_wasmtime",
+    wasm = ":clock_getres-monotonic",
+    runtime = "toolchains//:wasmtime_runtime",
+    suite = _WASI_C_SUITE,
+    labels = ["c-wasip1"],
+    visibility = ["//tests/..."],
+)
+
+cxx_binary(
+    name = "lseek",
+    srcs = ["src/lseek.c"],
+    _cxx_toolchain = "toolchains//:cxx_wasi_p1",
+    visibility = ["//tests/..."],
+)
+
+wasi_test(
+    name = "lseek_wasmtime",
+    wasm = ":lseek",
+    runtime = "toolchains//:wasmtime_runtime",
+    suite = _WASI_C_SUITE,
+    config = "src/lseek.json",
+    fixture_dirs = {
+        "fs-tests.dir": "src/fs-tests.dir",
+    },
+    labels = ["c-wasip1"],
+    visibility = ["//tests/..."],
+)
+
+test_suite(
+    name = "wasmtime",
+    tests = [
+        ":clock_getres-monotonic_wasmtime",
+        ":lseek_wasmtime",
+    ],
+    visibility = ["//tests/..."],
+)

--- a/tests/rust/wasm32-wasip1/BUCK
+++ b/tests/rust/wasm32-wasip1/BUCK
@@ -1,0 +1,57 @@
+load("//tools:conformance.bzl", "wasi_suite", "wasi_test")
+
+_WASI_RUST_SUITE = wasi_suite(
+    name = "WASI Rust tests [wasm32-wasip1]",
+    version = "wasm32-wasip1",
+)
+
+rust_binary(
+    name = "clock_time_get",
+    crate = "clock_time_get",
+    crate_root = "src/bin/clock_time_get.rs",
+    srcs = ["src/bin/clock_time_get.rs"],
+    edition = "2021",
+    deps = ["//third-party:wasi"],
+    _cxx_toolchain = "toolchains//:rust_linker",
+    _rust_toolchain = "toolchains//:rust_wasi_p1",
+    visibility = ["//tests/..."],
+)
+
+wasi_test(
+    name = "clock_time_get_wasmtime",
+    wasm = ":clock_time_get",
+    runtime = "toolchains//:wasmtime_runtime",
+    suite = _WASI_RUST_SUITE,
+    labels = ["rust-wasip1"],
+    visibility = ["//tests/..."],
+)
+
+rust_binary(
+    name = "sched_yield",
+    crate = "sched_yield",
+    crate_root = "src/bin/sched_yield.rs",
+    srcs = ["src/bin/sched_yield.rs"],
+    edition = "2021",
+    deps = ["//third-party:wasi"],
+    _cxx_toolchain = "toolchains//:rust_linker",
+    _rust_toolchain = "toolchains//:rust_wasi_p1",
+    visibility = ["//tests/..."],
+)
+
+wasi_test(
+    name = "sched_yield_wasmtime",
+    wasm = ":sched_yield",
+    runtime = "toolchains//:wasmtime_runtime",
+    suite = _WASI_RUST_SUITE,
+    labels = ["rust-wasip1"],
+    visibility = ["//tests/..."],
+)
+
+test_suite(
+    name = "wasmtime",
+    tests = [
+        ":clock_time_get_wasmtime",
+        ":sched_yield_wasmtime",
+    ],
+    visibility = ["//tests/..."],
+)

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -1,0 +1,22 @@
+load("@prelude//rust:cargo_package.bzl", "cargo")
+
+http_archive(
+    name = "wasi-0.11.0+wasi-snapshot-preview1.crate",
+    sha256 = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+    strip_prefix = "wasi-0.11.0+wasi-snapshot-preview1",
+    urls = [
+        "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download",
+    ],
+)
+
+cargo.rust_library(
+    name = "wasi",
+    srcs = [":wasi-0.11.0+wasi-snapshot-preview1.crate"],
+    crate = "wasi",
+    crate_root = "wasi-0.11.0+wasi-snapshot-preview1.crate/src/lib.rs",
+    doctests = False,
+    edition = "2018",
+    _cxx_toolchain = "toolchains//:rust_linker",
+    _rust_toolchain = "toolchains//:rust_wasi_p1",
+    visibility = ["PUBLIC"],
+)

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,0 +1,85 @@
+load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
+load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
+load("@prelude//toolchains:python.bzl", "remote_python_toolchain")
+load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
+load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
+load("@root//tools:runtime.bzl", "wasi_runtime")
+load(":runtimes.bzl", "download_wasmtime_runtime")
+load(
+    "@wasmono//:defs.bzl",
+    "asc_toolchain",
+    "cxx_wasi_toolchain",
+    "download_node",
+    "download_wasi_sdk",
+    "install_asc",
+    "node_toolchain",
+)
+
+# Host execution toolchains used by Buck rules and helper scripts.
+system_genrule_toolchain(name = "genrule", visibility = ["PUBLIC"])
+system_cxx_toolchain(name = "cxx", visibility = ["PUBLIC"])
+remote_python_toolchain(name = "python", visibility = ["PUBLIC"])
+
+# Rust toolchains: host Rust for ordinary Rust rules, plus a WASI P1 toolchain
+# for compiling Rust tests to wasm artifacts.
+system_rust_toolchain(
+    name = "rust",
+    default_edition = "2021",
+    visibility = ["PUBLIC"],
+)
+
+system_rust_toolchain(
+    name = "rust_wasi_p1",
+    default_edition = "2021",
+    rustc_target_triple = "wasm32-wasip1",
+    visibility = ["PUBLIC"],
+)
+
+# WASI SDK-based C/C++ toolchains. The C/C++ test toolchain emits WASI P1
+# modules; the wasm-ld variant is used as Rust's linker for the WASI target.
+download_wasi_sdk(name = "wasi_sdk", version = "27.0")
+
+cxx_wasi_toolchain(
+    name = "cxx_wasi_p1",
+    distribution = ":wasi_sdk",
+    c_compiler_flags = ["-Wno-unused-command-line-argument"],
+    cxx_compiler_flags = ["-Wno-unused-command-line-argument"],
+    target = "wasm32-wasip1",
+    visibility = ["PUBLIC"],
+)
+
+cxx_wasi_toolchain(
+    name = "rust_linker",
+    distribution = ":wasi_sdk",
+    linker_tool = "wasm-ld",
+    visibility = ["PUBLIC"],
+)
+
+# Runtime distributions and descriptors. The descriptor is what `wasi_test`
+# consumes, so adding a runtime means adding another descriptor target here.
+download_wasmtime_runtime(name = "wasmtime_dist", version = "45.0.0")
+
+wasi_runtime(
+    name = "wasmtime_runtime",
+    adapter = "root//adapters:wasmtime.py",
+    runtime = ":wasmtime_dist",
+    runtime_env_var = "WASMTIME",
+    labels = ["wasmtime"],
+    visibility = ["PUBLIC"],
+)
+
+# AssemblyScript compiler toolchain.
+download_node(name = "node_dist", version = "20.18.0")
+node_toolchain(name = "node", distribution = ":node_dist", visibility = ["PUBLIC"])
+
+install_asc(name = "asc_dist", version = "0.27.31", node = ":node_dist")
+asc_toolchain(name = "asc", distribution = ":asc_dist", visibility = ["PUBLIC"])
+
+# Test execution toolchains required by Buck's test command.
+noop_test_toolchain(name = "test", visibility = ["PUBLIC"])
+
+remote_test_execution_toolchain(
+    name = "remote_test_execution",
+    visibility = ["PUBLIC"],
+)

--- a/toolchains/releases.bzl
+++ b/toolchains/releases.bzl
@@ -1,0 +1,51 @@
+"""Release metadata for WASI runtime binaries."""
+
+WASMTIME_RELEASES = {
+    "45.0.0": {
+        "aarch64-linux": {
+            "url": (
+                "https://github.com/bytecodealliance/wasmtime/releases/" +
+                "download/v45.0.0/wasmtime-v45.0.0-aarch64-linux.tar.xz"
+            ),
+            "shasum": "4a27083ba8d3c64526b2d469f50e6539cb4c1dd9d08336e0d8953bca616737e3",
+            "prefix": "wasmtime-v45.0.0-aarch64-linux",
+            "binary": "wasmtime",
+        },
+        "aarch64-macos": {
+            "url": (
+                "https://github.com/bytecodealliance/wasmtime/releases/" +
+                "download/v45.0.0/wasmtime-v45.0.0-aarch64-macos.tar.xz"
+            ),
+            "shasum": "8c589a1feb6578ddfd76d4ee07bac551d7f3069d6cef9b2ae5e87e630b5198db",
+            "prefix": "wasmtime-v45.0.0-aarch64-macos",
+            "binary": "wasmtime",
+        },
+        "x86_64-linux": {
+            "url": (
+                "https://github.com/bytecodealliance/wasmtime/releases/" +
+                "download/v45.0.0/wasmtime-v45.0.0-x86_64-linux.tar.xz"
+            ),
+            "shasum": "9d92e6dc04630f617e0e5d532327a5a917ac4898587e07f4fb7a5fc7fffef760",
+            "prefix": "wasmtime-v45.0.0-x86_64-linux",
+            "binary": "wasmtime",
+        },
+        "x86_64-macos": {
+            "url": (
+                "https://github.com/bytecodealliance/wasmtime/releases/" +
+                "download/v45.0.0/wasmtime-v45.0.0-x86_64-macos.tar.xz"
+            ),
+            "shasum": "b01b421613d9e067103efb701cd66f436020b32f6e955125fac9eaf34fa5bce7",
+            "prefix": "wasmtime-v45.0.0-x86_64-macos",
+            "binary": "wasmtime",
+        },
+        "x86_64-windows": {
+            "url": (
+                "https://github.com/bytecodealliance/wasmtime/releases/" +
+                "download/v45.0.0/wasmtime-v45.0.0-x86_64-windows.zip"
+            ),
+            "shasum": "edb9572c6e8ae7c51053af826a8bc85bf205a759c9e83ddb08a941b26e297706",
+            "prefix": "wasmtime-v45.0.0-x86_64-windows",
+            "binary": "wasmtime",
+        },
+    },
+}

--- a/toolchains/runtimes.bzl
+++ b/toolchains/runtimes.bzl
@@ -1,0 +1,77 @@
+"""Download rules for WASI runtime binaries used by the test suite."""
+
+load("@wasmono//:defs.bzl", "host_arch", "host_os")
+load(":releases.bzl", "WASMTIME_RELEASES")
+
+def _runtime_platform() -> str:
+    return "{}-{}".format(host_arch(), host_os())
+
+def _runtime_release(releases, runtime_name: str, version: str):
+    platform = _runtime_platform()
+    if version not in releases:
+        fail("Unknown {} version '{}'. Available: {}".format(
+            runtime_name,
+            version,
+            ", ".join(releases.keys()),
+        ))
+
+    release = releases[version]
+    if platform not in release:
+        fail("No {} release for platform '{}'. Available: {}".format(
+            runtime_name,
+            platform,
+            ", ".join(release.keys()),
+        ))
+    return release[platform]
+
+def _runtime_distribution_impl(ctx: AnalysisContext) -> list[Provider]:
+    dist = ctx.attrs.dist[DefaultInfo].default_outputs[0]
+    binary_path = ctx.attrs.binary
+
+    if ctx.attrs.prefix:
+        binary_path = "{}/{}".format(ctx.attrs.prefix, ctx.attrs.binary)
+
+    binary = dist.project(binary_path)
+
+    run = cmd_args(
+        [binary],
+        hidden = [
+            ctx.attrs.dist[DefaultInfo].default_outputs,
+            ctx.attrs.dist[DefaultInfo].other_outputs,
+        ],
+    )
+
+    return [
+        DefaultInfo(default_output = binary),
+        RunInfo(args = run),
+    ]
+
+_runtime_distribution = rule(
+    impl = _runtime_distribution_impl,
+    attrs = {
+        "dist": attrs.dep(providers = [DefaultInfo]),
+        "binary": attrs.string(),
+        "prefix": attrs.string(default = ""),
+    },
+)
+
+def _download_runtime(name: str, releases, runtime_name: str, version: str):
+    release = _runtime_release(releases, runtime_name, version)
+
+    native.http_archive(
+        name = name + "-archive",
+        urls = [release["url"]],
+        sha256 = release["shasum"],
+    )
+
+    _runtime_distribution(
+        name = name,
+        dist = ":" + name + "-archive",
+        binary = release["binary"] + (".exe" if host_os() == "windows" else ""),
+        prefix = release.get("prefix", ""),
+        visibility = ["PUBLIC"],
+    )
+
+def download_wasmtime_runtime(name: str, version: str = "45.0.0"):
+    """Download a prebuilt Wasmtime runtime."""
+    _download_runtime(name, WASMTIME_RELEASES, "wasmtime", version)

--- a/tools/BUCK
+++ b/tools/BUCK
@@ -1,0 +1,7 @@
+python_binary(
+    name = "run_wasi_test",
+    main = "run_wasi_test.py",
+    base_module = "",
+    deps = ["//test-runner:wasi_test_runner"],
+    visibility = ["//tests/..."],
+)

--- a/tools/conformance.bzl
+++ b/tools/conformance.bzl
@@ -1,0 +1,141 @@
+"""Rules for turning Buck-built wasm artifacts into WASI conformance tests.
+
+The build target that produces a `.wasm` file should stay language-specific
+(`cxx_binary`, `rust_binary`, `assemblyscript_binary`, ...). The generic
+`wasi_test` rule adds the runtime dimension by pairing that artifact with a
+`WasiRuntimeInfo` provider and delegating execution to the existing
+`wasi_test_runner`.
+
+`wasi_suite` is reporting metadata consumed by the Python runner. Runtime
+grouping should be represented with Buck `test_suite` targets, for example a
+package-level `test_suite(name = "wasmtime", tests = [":lseek_wasmtime"])`.
+"""
+
+load("@prelude//decls:common.bzl", "buck")
+load("@prelude//test:inject_test_run_info.bzl", "inject_test_run_info")
+load(":runtime.bzl", "WasiRuntimeInfo")
+
+def wasi_suite(name: str, version: str):
+    """Create suite metadata written into the staged runner manifest."""
+    return struct(
+        name = name,
+        version = version,
+    )
+
+def _infer_test_name(wasm):
+    if type(wasm) != type(""):
+        fail("wasi_test: test_name is required when wasm is not a label string")
+    if ":" not in wasm:
+        fail("wasi_test: cannot infer test_name from '{}'; pass test_name explicitly".format(wasm))
+    return wasm.rsplit(":", 1)[1]
+
+def _single_output(dep, attr_name):
+    outputs = dep[DefaultInfo].default_outputs
+    if len(outputs) != 1:
+        fail("{} must provide exactly one output, got {}".format(attr_name, len(outputs)))
+    return outputs[0]
+
+def _wasi_test_impl(ctx: AnalysisContext) -> list[Provider]:
+    wasm = _single_output(ctx.attrs.wasm, "wasm")
+    runtime_info = ctx.attrs.runtime[WasiRuntimeInfo]
+    runtime = runtime_info.runtime
+    exclude_filter = ctx.attrs.exclude_filter or runtime_info.exclude_filter
+
+    cmd = cmd_args(ctx.attrs._runner[RunInfo])
+    cmd.add("--wasm", wasm)
+    cmd.add("--test-name", ctx.attrs.test_name)
+    cmd.add("--suite-name", ctx.attrs.suite_name)
+    cmd.add("--wasi-version", ctx.attrs.wasi_version)
+    cmd.add("--adapter", runtime_info.adapter)
+
+    if ctx.attrs.config:
+        cmd.add("--config", ctx.attrs.config)
+
+    for guest_name, host_dir in ctx.attrs.fixture_dirs.items():
+        cmd.add("--fixture-dir", guest_name, host_dir)
+
+    if exclude_filter:
+        cmd.add("--exclude-filter", exclude_filter)
+
+    test_env = {
+        runtime_info.runtime_env_var: runtime[RunInfo].args,
+    }
+    if runtime[DefaultInfo].default_outputs:
+        cmd.add(cmd_args(hidden = runtime[DefaultInfo].default_outputs))
+
+    return inject_test_run_info(
+        ctx,
+        ExternalRunnerTestInfo(
+            type = "custom",
+            command = [cmd],
+            env = test_env,
+            labels = runtime_info.labels + ctx.attrs.labels,
+        ),
+    ) + [
+        DefaultInfo(default_output = wasm),
+    ]
+
+_wasi_test_rule = rule(
+    impl = _wasi_test_impl,
+    attrs = {
+        "wasm": attrs.dep(providers = [DefaultInfo]),
+        "test_name": attrs.string(),
+        "suite_name": attrs.string(),
+        "wasi_version": attrs.string(),
+        "runtime": attrs.dep(providers = [WasiRuntimeInfo]),
+        "config": attrs.option(attrs.source(), default = None),
+        "fixture_dirs": attrs.dict(
+            key = attrs.string(),
+            value = attrs.source(allow_directory = True),
+            default = {},
+        ),
+        "exclude_filter": attrs.option(attrs.source(), default = None),
+        "_runner": attrs.exec_dep(
+            default = "//tools:run_wasi_test",
+            providers = [RunInfo],
+        ),
+    } | buck.labels_arg() | buck.inject_test_env_arg(),
+)
+
+def wasi_test(
+        name: str,
+        wasm,
+        runtime,
+        suite,
+        config = None,
+        fixture_dirs = {},
+        exclude_filter = None,
+        test_name = None,
+        labels = [],
+        visibility = None):
+    """Run one Buck-built wasm artifact against one WASI runtime.
+
+    Args:
+        name: Buck target name for this test/runtime cell, e.g. `lseek_wasmtime`.
+        wasm: Target producing the `.wasm` artifact under test.
+        runtime: Target providing `WasiRuntimeInfo`.
+        suite: Metadata from `wasi_suite`.
+        config: Optional runner JSON config for this test.
+        fixture_dirs: Mutable preopened directories staged for the runner.
+        exclude_filter: Optional runner exclude filter overriding the runtime default.
+        test_name: Optional runner test name; inferred from `wasm` labels.
+        labels: Extra Buck test labels.
+        visibility: Optional Buck visibility.
+    """
+    kwargs = {}
+    if visibility != None:
+        kwargs["visibility"] = visibility
+
+    _wasi_test_rule(
+        name = name,
+        wasm = wasm,
+        runtime = runtime,
+        suite_name = suite.name,
+        wasi_version = suite.version,
+        test_name = test_name or _infer_test_name(wasm),
+        config = config,
+        fixture_dirs = fixture_dirs,
+        exclude_filter = exclude_filter,
+        labels = labels,
+        **kwargs
+    )

--- a/tools/run_wasi_test.py
+++ b/tools/run_wasi_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Run a single Buck-built WASI test through wasi_test_runner."""
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from wasi_test_runner.harness import run_tests
+from wasi_test_runner.runtime_adapter import RuntimeAdapter
+
+
+def _copy_file(src: str, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def _copy_tree(src: str, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, symlinks=True)
+
+
+def _write_manifest(path: Path, name: str, version: str) -> None:
+    manifest = {
+        "name": name,
+        "version": version,
+    }
+    path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    """Materialize a one-test suite and delegate execution to the runner."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wasm", required=True)
+    parser.add_argument("--test-name", required=True)
+    parser.add_argument("--suite-name", required=True)
+    parser.add_argument("--wasi-version", required=True)
+    parser.add_argument("--adapter", required=True)
+    parser.add_argument("--config")
+    parser.add_argument("--fixture-dir", nargs=2, action="append", default=[])
+    parser.add_argument("--exclude-filter")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="wasi-buck-test-") as tmp:
+        suite_dir = Path(tmp)
+        _write_manifest(suite_dir / "manifest.json", args.suite_name, args.wasi_version)
+        _copy_file(args.wasm, suite_dir / f"{args.test_name}.wasm")
+
+        if args.config:
+            _copy_file(args.config, suite_dir / f"{args.test_name}.json")
+
+        for guest_name, host_dir in args.fixture_dir:
+            _copy_tree(host_dir, suite_dir / guest_name)
+
+        runtime = RuntimeAdapter(Path(args.adapter))
+        exclude_filters = [Path(args.exclude_filter)] if args.exclude_filter else None
+        return run_tests([runtime], [suite_dir], exclude_filters)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/runtime.bzl
+++ b/tools/runtime.bzl
@@ -1,0 +1,47 @@
+"""Runtime descriptors used by generic WASI conformance tests.
+
+A runtime target packages the parts that vary across the runtime matrix:
+adapter plugin, executable, environment variable name, optional runner exclude
+filter, and Buck labels. Language packages should depend on this provider
+through `wasi_test`.
+"""
+
+WasiRuntimeInfo = provider(
+    doc = "Provider describing one WASI runtime configuration.",
+    fields = {
+        # Python runtime adapter plugin loaded by the existing runner.
+        "adapter": provider_field(Artifact),
+        # Executable target providing RunInfo for the runtime binary.
+        "runtime": provider_field(typing.Any),
+        # Environment variable consumed by the adapter, e.g. WASMTIME.
+        "runtime_env_var": provider_field(str),
+        # Optional runner exclude filter for this runtime.
+        "exclude_filter": provider_field(Artifact | None, default = None),
+        # Buck test labels added to every test using this runtime.
+        "labels": provider_field(list[str], default = []),
+    },
+)
+
+def _wasi_runtime_impl(ctx: AnalysisContext) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        WasiRuntimeInfo(
+            adapter = ctx.attrs.adapter,
+            runtime = ctx.attrs.runtime,
+            runtime_env_var = ctx.attrs.runtime_env_var,
+            exclude_filter = ctx.attrs.exclude_filter,
+            labels = ctx.attrs.labels,
+        ),
+    ]
+
+wasi_runtime = rule(
+    impl = _wasi_runtime_impl,
+    attrs = {
+        "adapter": attrs.source(doc = "Python adapter plugin file for wasi_test_runner."),
+        "runtime": attrs.dep(providers = [RunInfo], doc = "Runtime executable target."),
+        "runtime_env_var": attrs.string(doc = "Environment variable used to pass the runtime command to the adapter."),
+        "exclude_filter": attrs.option(attrs.source(), default = None, doc = "Optional default exclude filter for this runtime."),
+        "labels": attrs.list(attrs.string(), default = [], doc = "Labels propagated to tests that use this runtime."),
+    },
+    doc = "Create a WASI runtime descriptor consumed by `wasi_test`.",
+)


### PR DESCRIPTION
Introduce a deliberately small Buck2 slice for running few C, Rust, and AssemblyScript wasi Preview 1 tests with Wasmtime through the existing python test runner. This keeps the PR focused on testing the direction and starting discussion, without attempting a broad test-suite refactor just yet. 

See [quickstart](https://github.com/andreiltd/wasi-testsuite/tree/buck2-port-foundation#experimental-buck2-workflow) and https://github.com/WebAssembly/wasi-testsuite/issues/226 for more details on motivation.