### PR TITLE
feat(buck2): add rule for creating dist package

### DIFF
--- a/.github/workflows/buck2.yml
+++ b/.github/workflows/buck2.yml
@@ -41,10 +41,15 @@ jobs:
 
       - name: Configure Buck2 launcher on Windows
         if: runner.os == 'Windows'
-        run: echo 'BUCK2=dotslash ./buck2' >> "$GITHUB_ENV"
+        run: |
+          echo 'BUCK2=dotslash ./buck2' >> "$GITHUB_ENV"
+          echo 'MSYS2_ARG_CONV_EXCL=//' >> "$GITHUB_ENV"
 
       - name: Run Starlark lint
         run: just lint-starlark
 
       - name: Run Buck2 tests
         run: just test-all
+
+      - name: Build dist archive
+        run: just dist

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,5 @@
+export_file(
+    name = "run-tests",
+    src = "run-tests",
+    visibility = ["//tests/..."],
+)

--- a/README.md
+++ b/README.md
@@ -84,11 +84,33 @@ using the checked-in `./buck2` launcher, for example with `cargo install dotslas
 ./buck2 test //tests/...
 ```
 
+Build the Buck produced test data archive with:
+
+```bash
+./buck2 build --show-output //tests:dist
+```
+
+The archive includes the test runner, adapters, Python requirements, and Buck built
+test data. It can be run like this:
+
+```bash
+# extract:
+mkdir -p dist
+tar -xzf buck-out/.../wasi-testsuite.tar.gz -C dist
+# setup Python:
+python3 -m venv dist/venv
+dist/venv/bin/python -m pip install -r dist/wasi-testsuite/test-runner/requirements.txt
+# run:
+cd dist/wasi-testsuite
+WASMTIME=/path/to/wasmtime ../venv/bin/python ./run-tests --runtime-adapter adapters/wasmtime.py
+```
+
 or if you prefer using `just`
 
 ```bash
 just build
 just test
+just dist
 ```
 
 The Buck2 lint helpers mirror the CI checks:

--- a/adapters/BUCK
+++ b/adapters/BUCK
@@ -6,3 +6,11 @@ export_file(
         "//tests/...",
     ],
 )
+
+filegroup(
+    name = "dist_files",
+    srcs = glob(["*.py"]),
+    out = "adapters",
+    copy = True,
+    visibility = ["//tests/..."],
+)

--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ targets:
 build:
     {{buck}} build //...
 
+# Build the distribution archive.
+dist:
+    {{buck}} build --show-output //tests:dist
+
 # Run the Buck2 first-slice Wasmtime tests.
 test:
     {{buck}} test //tests:wasmtime

--- a/test-runner/BUCK
+++ b/test-runner/BUCK
@@ -8,6 +8,18 @@ python_library(
     ]
 )
 
+filegroup(
+    name = "dist_files",
+    srcs = glob(["wasi_test_runner/**/*.py"]) + [
+        "requirements.txt",
+        "requirements/common.txt",
+        "requirements/prod.txt",
+    ],
+    out = "test-runner",
+    copy = True,
+    visibility = ["//tests/..."],
+)
+
 remote_file(
     name = "colorama-download",
     url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
@@ -19,3 +31,4 @@ prebuilt_python_library(
     name = "colorama",
     binary_src = ":colorama-download",
 )
+

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -1,8 +1,21 @@
-test_suite(
+load("//tools:conformance.bzl", "wasi_suite")
+load("//tools:dist.bzl", "wasi_dist")
+
+wasi_suite(
     name = "wasmtime",
     tests = [
         "//tests/c:wasmtime",
         "//tests/rust/wasm32-wasip1:wasmtime",
         "//tests/assemblyscript/wasm32-wasip1:wasmtime",
     ],
+)
+
+wasi_dist(
+    name = "dist",
+    suites = [":wasmtime"],
+    extra_files = {
+        "run-tests": "//:run-tests",
+        "adapters": "//adapters:dist_files",
+        "test-runner": "//test-runner:dist_files",
+    },
 )

--- a/tests/assemblyscript/wasm32-wasip1/BUCK
+++ b/tests/assemblyscript/wasm32-wasip1/BUCK
@@ -1,9 +1,10 @@
 load("@wasmono//:defs.bzl", "assemblyscript_binary")
-load("//tools:conformance.bzl", "wasi_suite", "wasi_test")
+load("//tools:conformance.bzl", "wasi_manifest", "wasi_suite", "wasi_test")
 
-_WASI_ASSEMBLYSCRIPT_SUITE = wasi_suite(
-    name = "WASI AssemblyScript tests [wasm32-wasip1]",
+_WASI_ASSEMBLYSCRIPT = wasi_manifest(
+    name = "WASI AssemblyScript tests",
     version = "wasm32-wasip1",
+    labels = ["assemblyscript-wasip1"],
 )
 
 assemblyscript_binary(
@@ -16,9 +17,8 @@ wasi_test(
     name = "args_get-multiple-arguments_wasmtime",
     wasm = ":args_get-multiple-arguments",
     runtime = "toolchains//:wasmtime_runtime",
-    suite = _WASI_ASSEMBLYSCRIPT_SUITE,
+    manifest = _WASI_ASSEMBLYSCRIPT,
     config = "src/args_get-multiple-arguments.json",
-    labels = ["assemblyscript-wasip1"],
     visibility = ["//tests/..."],
 )
 
@@ -32,13 +32,12 @@ wasi_test(
     name = "fd_write-to-stdout_wasmtime",
     wasm = ":fd_write-to-stdout",
     runtime = "toolchains//:wasmtime_runtime",
-    suite = _WASI_ASSEMBLYSCRIPT_SUITE,
+    manifest = _WASI_ASSEMBLYSCRIPT,
     config = "src/fd_write-to-stdout.json",
-    labels = ["assemblyscript-wasip1"],
     visibility = ["//tests/..."],
 )
 
-test_suite(
+wasi_suite(
     name = "wasmtime",
     tests = [
         ":args_get-multiple-arguments_wasmtime",

--- a/tests/c/BUCK
+++ b/tests/c/BUCK
@@ -1,8 +1,9 @@
-load("//tools:conformance.bzl", "wasi_suite", "wasi_test")
+load("//tools:conformance.bzl", "wasi_manifest", "wasi_suite", "wasi_test")
 
-_WASI_C_SUITE = wasi_suite(
-    name = "WASI C tests [wasm32-wasip1]",
+_WASI_C = wasi_manifest(
+    name = "WASI C tests",
     version = "wasm32-wasip1",
+    labels = ["c-wasip1"],
 )
 
 cxx_binary(
@@ -16,8 +17,7 @@ wasi_test(
     name = "clock_getres-monotonic_wasmtime",
     wasm = ":clock_getres-monotonic",
     runtime = "toolchains//:wasmtime_runtime",
-    suite = _WASI_C_SUITE,
-    labels = ["c-wasip1"],
+    manifest = _WASI_C,
     visibility = ["//tests/..."],
 )
 
@@ -32,16 +32,15 @@ wasi_test(
     name = "lseek_wasmtime",
     wasm = ":lseek",
     runtime = "toolchains//:wasmtime_runtime",
-    suite = _WASI_C_SUITE,
+    manifest = _WASI_C,
     config = "src/lseek.json",
     fixture_dirs = {
         "fs-tests.dir": "src/fs-tests.dir",
     },
-    labels = ["c-wasip1"],
     visibility = ["//tests/..."],
 )
 
-test_suite(
+wasi_suite(
     name = "wasmtime",
     tests = [
         ":clock_getres-monotonic_wasmtime",

--- a/tests/rust/wasm32-wasip1/BUCK
+++ b/tests/rust/wasm32-wasip1/BUCK
@@ -1,8 +1,9 @@
-load("//tools:conformance.bzl", "wasi_suite", "wasi_test")
+load("//tools:conformance.bzl", "wasi_manifest", "wasi_suite", "wasi_test")
 
-_WASI_RUST_SUITE = wasi_suite(
-    name = "WASI Rust tests [wasm32-wasip1]",
+_WASI_RUST = wasi_manifest(
+    name = "WASI Rust tests",
     version = "wasm32-wasip1",
+    labels = ["rust-wasip1"],
 )
 
 rust_binary(
@@ -21,8 +22,7 @@ wasi_test(
     name = "clock_time_get_wasmtime",
     wasm = ":clock_time_get",
     runtime = "toolchains//:wasmtime_runtime",
-    suite = _WASI_RUST_SUITE,
-    labels = ["rust-wasip1"],
+    manifest = _WASI_RUST,
     visibility = ["//tests/..."],
 )
 
@@ -42,12 +42,11 @@ wasi_test(
     name = "sched_yield_wasmtime",
     wasm = ":sched_yield",
     runtime = "toolchains//:wasmtime_runtime",
-    suite = _WASI_RUST_SUITE,
-    labels = ["rust-wasip1"],
+    manifest = _WASI_RUST,
     visibility = ["//tests/..."],
 )
 
-test_suite(
+wasi_suite(
     name = "wasmtime",
     tests = [
         ":clock_time_get_wasmtime",

--- a/tools/BUCK
+++ b/tools/BUCK
@@ -5,3 +5,9 @@ python_binary(
     deps = ["//test-runner:wasi_test_runner"],
     visibility = ["//tests/..."],
 )
+
+python_binary(
+    name = "package_dist",
+    main = "package_dist.py",
+    visibility = ["//tests/..."],
+)

--- a/tools/conformance.bzl
+++ b/tools/conformance.bzl
@@ -2,23 +2,55 @@
 
 The build target that produces a `.wasm` file should stay language-specific
 (`cxx_binary`, `rust_binary`, `assemblyscript_binary`, ...). The generic
-`wasi_test` rule adds the runtime dimension by pairing that artifact with a
+`wasi_test` macro adds the runtime dimension by pairing those artifacts with a
 `WasiRuntimeInfo` provider and delegating execution to the existing
 `wasi_test_runner`.
 
-`wasi_suite` is reporting metadata consumed by the Python runner. Runtime
-grouping should be represented with Buck `test_suite` targets, for example a
-package-level `test_suite(name = "wasmtime", tests = [":lseek_wasmtime"])`.
+`wasi_manifest` captures runner and distribution metadata.
+`wasi_test` targets pair a wasm artifact with a runtime and manifest.
+`wasi_suite` groups those targets for `buck2 test` and distribution packaging.
 """
 
 load("@prelude//decls:common.bzl", "buck")
 load("@prelude//test:inject_test_run_info.bzl", "inject_test_run_info")
 load(":runtime.bzl", "WasiRuntimeInfo")
 
-def wasi_suite(name: str, version: str):
-    """Create suite metadata written into the staged runner manifest."""
+WasiTestInfo = provider(
+    doc = "Provider describing one WASI test for dist packaging.",
+    fields = {
+        "config": provider_field(Artifact | None, default = None),
+        "dist_dir": provider_field(str | None, default = None),
+        "fixture_dirs": provider_field(dict[str, Artifact], default = {}),
+        "suite_name": provider_field(str),
+        "test_name": provider_field(str),
+        "wasm": provider_field(Artifact),
+        "wasi_version": provider_field(str),
+    },
+)
+
+WasiTestSuiteInfo = provider(
+    doc = "Provider collecting WASI test metadata for dist packaging.",
+    fields = {
+        "tests": provider_field(list[WasiTestInfo]),
+    },
+)
+
+def _default_dist_dir(wasi_version: str) -> str:
+    package = package_name()
+    if package.endswith("/" + wasi_version):
+        package = package.removesuffix("/" + wasi_version)
+    return "{}/testsuite/{}".format(package, wasi_version)
+
+def wasi_manifest(
+        name: str,
+        version: str,
+        dist_dir: str | None = None,
+        labels: list[str] = []):
+    """Create runner manifest and dist metadata."""
     return struct(
-        name = name,
+        dist_dir = dist_dir or _default_dist_dir(version),
+        labels = labels,
+        name = "{} [{}]".format(name, version),
         version = version,
     )
 
@@ -60,6 +92,7 @@ def _wasi_test_impl(ctx: AnalysisContext) -> list[Provider]:
     test_env = {
         runtime_info.runtime_env_var: runtime[RunInfo].args,
     }
+
     if runtime[DefaultInfo].default_outputs:
         cmd.add(cmd_args(hidden = runtime[DefaultInfo].default_outputs))
 
@@ -73,6 +106,15 @@ def _wasi_test_impl(ctx: AnalysisContext) -> list[Provider]:
         ),
     ) + [
         DefaultInfo(default_output = wasm),
+        WasiTestInfo(
+            config = ctx.attrs.config,
+            dist_dir = ctx.attrs.suite_dist_dir,
+            fixture_dirs = ctx.attrs.fixture_dirs,
+            suite_name = ctx.attrs.suite_name,
+            test_name = ctx.attrs.test_name,
+            wasm = wasm,
+            wasi_version = ctx.attrs.wasi_version,
+        ),
     ]
 
 _wasi_test_rule = rule(
@@ -90,6 +132,7 @@ _wasi_test_rule = rule(
             default = {},
         ),
         "exclude_filter": attrs.option(attrs.source(), default = None),
+        "suite_dist_dir": attrs.option(attrs.string(), default = None),
         "_runner": attrs.exec_dep(
             default = "//tools:run_wasi_test",
             providers = [RunInfo],
@@ -101,8 +144,9 @@ def wasi_test(
         name: str,
         wasm,
         runtime,
-        suite,
+        manifest,
         config = None,
+        dist_dir: str | None = None,
         fixture_dirs = {},
         exclude_filter = None,
         test_name = None,
@@ -114,12 +158,13 @@ def wasi_test(
         name: Buck target name for this test/runtime cell, e.g. `lseek_wasmtime`.
         wasm: Target producing the `.wasm` artifact under test.
         runtime: Target providing `WasiRuntimeInfo`.
-        suite: Metadata from `wasi_suite`.
+        manifest: Metadata returned by `wasi_manifest`.
         config: Optional runner JSON config for this test.
+        dist_dir: Optional archive relative dist directory; derived from package and version by default.
         fixture_dirs: Mutable preopened directories staged for the runner.
         exclude_filter: Optional runner exclude filter overriding the runtime default.
-        test_name: Optional runner test name; inferred from `wasm` labels.
-        labels: Extra Buck test labels.
+        test_name: Optional runner/dist test name; inferred from `wasm` labels.
+        labels: Extra Buck test labels appended to manifest labels.
         visibility: Optional Buck visibility.
     """
     kwargs = {}
@@ -130,12 +175,61 @@ def wasi_test(
         name = name,
         wasm = wasm,
         runtime = runtime,
-        suite_name = suite.name,
-        wasi_version = suite.version,
+        suite_name = manifest.name,
+        suite_dist_dir = dist_dir or manifest.dist_dir,
+        wasi_version = manifest.version,
         test_name = test_name or _infer_test_name(wasm),
         config = config,
         fixture_dirs = fixture_dirs,
         exclude_filter = exclude_filter,
-        labels = labels,
+        labels = manifest.labels + labels,
+        **kwargs
+    )
+
+def _wasi_test_suite_impl(ctx: AnalysisContext) -> list[Provider]:
+    tests = []
+    test_targets = []
+    other_outputs = []
+
+    for test in ctx.attrs.test_deps:
+        # Mirror test_suite shape so buck2 test traverses this target.
+        test_targets.append(test.label.raw_target())
+        default_info = test[DefaultInfo]
+        other_outputs.extend(default_info.default_outputs)
+        other_outputs.extend(default_info.other_outputs)
+
+        # Collect test metadata, flattening nested wasi_suite targets.
+        if WasiTestInfo in test:
+            tests.append(test[WasiTestInfo])
+        elif WasiTestSuiteInfo in test:
+            tests.extend(test[WasiTestSuiteInfo].tests)
+        else:
+            fail("{} does not provide WasiTestInfo or WasiTestSuiteInfo".format(test.label))
+
+    return [
+        DefaultInfo(
+            default_outputs = [ctx.actions.write("test_targets.txt", test_targets, has_content_based_path = False)],
+            other_outputs = other_outputs,
+        ),
+        WasiTestSuiteInfo(tests = tests),
+    ]
+
+_wasi_test_suite_rule = rule(
+    impl = _wasi_test_suite_impl,
+    attrs = {
+        "test_deps": attrs.list(attrs.dep(), default = []),
+    },
+)
+
+def wasi_suite(name: str, tests: list[str], visibility = None):
+    """Group WASI tests for `buck2 test` and aggregate metadata for `wasi_dist`."""
+    kwargs = {}
+    if visibility != None:
+        kwargs["visibility"] = visibility
+
+    _wasi_test_suite_rule(
+        name = name,
+        test_deps = tests,
+        tests = tests,
         **kwargs
     )

--- a/tools/dist.bzl
+++ b/tools/dist.bzl
@@ -1,0 +1,104 @@
+"""Rules for packaging WASI tests into a distribution archive."""
+
+load("//tools:conformance.bzl", "WasiTestSuiteInfo")
+
+def _single_output(dep, attr_name):
+    outputs = dep[DefaultInfo].default_outputs
+    if len(outputs) != 1:
+        fail("{} must provide exactly one output, got {}".format(attr_name, len(outputs)))
+    return outputs[0]
+
+def _add_item(items, path, src):
+    if src == None:
+        return
+    if path not in items:
+        items[path] = src
+
+def _wasi_dist_impl(ctx: AnalysisContext) -> list[Provider]:
+    output = ctx.actions.declare_output("wasi-testsuite.tar.gz")
+    spec = ctx.actions.declare_output("dist-spec.json")
+
+    manifests = {}
+    item_map = {}
+
+    for suite in ctx.attrs.suites:
+        for test in suite[WasiTestSuiteInfo].tests:
+            if test.dist_dir == None:
+                fail("{} does not set dist_dir in wasi_test".format(test.test_name))
+
+            manifest_path = "{}/manifest.json".format(test.dist_dir)
+            manifest = {
+                "name": test.suite_name,
+                "version": test.wasi_version,
+            }
+
+            if manifest_path in manifests and manifests[manifest_path] != manifest:
+                fail("conflicting manifest metadata for {}".format(manifest_path))
+
+            manifests[manifest_path] = manifest
+
+            _add_item(item_map, "{}/{}.wasm".format(test.dist_dir, test.test_name), test.wasm)
+            _add_item(item_map, "{}/{}.json".format(test.dist_dir, test.test_name), test.config)
+
+            for guest_name, fixture_dir in test.fixture_dirs.items():
+                _add_item(item_map, "{}/{}".format(test.dist_dir, guest_name), fixture_dir)
+
+    for dst, src in ctx.attrs.extra_files.items():
+        _add_item(item_map, dst, _single_output(src, "extra_files[{}]".format(dst)))
+
+    items = [
+        {
+            "dst": path,
+            "src": src,
+        }
+        for path, src in item_map.items()
+    ]
+
+    ctx.actions.write_json(spec, {
+        "root": ctx.attrs.root,
+        "manifests": [
+            {
+                "dst": path,
+                "content": content,
+            }
+            for path, content in manifests.items()
+        ],
+        "items": items,
+    }, with_inputs = True)
+
+    ctx.actions.run(
+        cmd_args(
+            ctx.attrs._package_script[RunInfo],
+            "--spec",
+            spec,
+            "--output",
+            output.as_output(),
+            hidden = [item["src"] for item in items],
+        ),
+        category = "wasi_dist",
+    )
+
+    return [DefaultInfo(default_output = output)]
+
+wasi_dist = rule(
+    impl = _wasi_dist_impl,
+    attrs = {
+        "root": attrs.string(default = "wasi-testsuite"),
+        "suites": attrs.list(
+            attrs.dep(providers = [WasiTestSuiteInfo]),
+            default = [],
+            doc = "WASI test suite targets to include in the archive.",
+        ),
+        "extra_files": attrs.dict(
+            key = attrs.string(),
+            value = attrs.dep(providers = [DefaultInfo]),
+            default = {},
+            doc = "Additional files or directories to include at archive-relative paths.",
+        ),
+        "_package_script": attrs.exec_dep(
+            default = "//tools:package_dist",
+            providers = [RunInfo],
+        ),
+    },
+    doc = "Create a deterministic wasi-testsuite tarball from declared inputs.",
+)

--- a/tools/package_dist.py
+++ b/tools/package_dist.py
@@ -1,0 +1,85 @@
+"""Package declared WASI testsuite inputs into a deterministic tarball."""
+
+import argparse
+import gzip
+import io
+import json
+import stat
+import tarfile
+from pathlib import Path
+from typing import Any
+
+
+def _reset_metadata(info: tarfile.TarInfo) -> tarfile.TarInfo:
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.mtime = 0
+    return info
+
+
+def _add_directory_entry(tar: tarfile.TarFile, arcname: str) -> None:
+    info = tarfile.TarInfo(arcname.rstrip("/") + "/")
+    info.type = tarfile.DIRTYPE
+    info.mode = 0o755
+    tar.addfile(_reset_metadata(info))
+
+
+def _normalize_input(info: tarfile.TarInfo) -> tarfile.TarInfo:
+    _reset_metadata(info)
+    if info.isdir():
+        info.mode = 0o755
+    elif info.issym():
+        info.mode = 0o777
+    elif info.isfile():
+        info.mode = stat.S_IMODE(info.mode)
+    else:
+        raise FileNotFoundError(info.name)
+    return info
+
+
+def _add_path(tar: tarfile.TarFile, src: Path, arcname: str) -> None:
+    if not (src.is_symlink() or src.is_dir() or src.is_file()):
+        raise FileNotFoundError(src)
+    tar.add(src, arcname=arcname, recursive=True, filter=_normalize_input)
+
+
+def _add_manifest(tar: tarfile.TarFile, manifest: dict[str, Any], arcname: str) -> None:
+    data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    info = tarfile.TarInfo(arcname)
+    info.size = len(data)
+    info.mode = 0o644
+    tar.addfile(_reset_metadata(info), io.BytesIO(data))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    with open(args.spec, encoding="utf-8") as file:
+        spec = json.load(file)
+
+    root = spec["root"].rstrip("/")
+    with open(args.output, "wb") as raw:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as gz:
+            with tarfile.open(fileobj=gz, mode="w") as tar:
+                _add_directory_entry(tar, root)
+                entries = [
+                    ("manifest", manifest["dst"], manifest)
+                    for manifest in spec["manifests"]
+                ] + [
+                    ("item", item["dst"], item)
+                    for item in spec["items"]
+                ]
+                for kind, dst, entry in sorted(entries, key=lambda item: item[1]):
+                    if kind == "manifest":
+                        _add_manifest(tar, entry["content"], f"{root}/{dst}")
+                    else:
+                        _add_path(tar, Path(entry["src"]), f"{root}/{dst}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The patch adds provider metadata for buck wasi tests so package level `wasi_suite` targets can collect test artifacts for distribution.

Add a `wasi_dist` rule that builds a deterministic wasi-testsuite.tar.gz containing the runner, adapters, Python requirements, and all buck build artifacts required to run tests.

The easiest way to test is to run:

```
just dist
```

and it will print where the dist package has been created:

```
BUILD SUCCEEDED
root//tests:dist buck-out/v2/art/root/5c1b01ec01a662a2/tests/__dist__/wasi-testsuite.tar.gz
```

`wasi_dist` macro collects test from `wasi_suites` so it's easy to add sub targets, like for example dist package that contains only rust tests:

```
wasi_dist(
    name = "dist-rust",
    suites = ["//tests/rust/wasm32-wasip1:wasmtime"],
)
```