### PR TITLE
feat(buck2): add extra wasi runtime coverage

### DIFF
--- a/.github/workflows/buck2.yml
+++ b/.github/workflows/buck2.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   buck2:
-    name: Buck2 smoke test (${{ matrix.os }})
+    name: Buck2 tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -48,8 +48,12 @@ jobs:
       - name: Run Starlark lint
         run: just lint-starlark
 
-      - name: Run Buck2 tests
-        run: just test-all
+      - name: Run Wasmtime Buck tests
+        run: just test
+
+      - name: Run extra Buck runtime tests
+        if: runner.os == 'Linux'
+        run: just test-extra-runtimes
 
       - name: Build dist archive
         run: just dist

--- a/adapters/BUCK
+++ b/adapters/BUCK
@@ -7,6 +7,33 @@ export_file(
     ],
 )
 
+export_file(
+    name = "wazero.py",
+    src = "wazero.py",
+    visibility = [
+        "toolchains//...",
+        "//tests/...",
+    ],
+)
+
+export_file(
+    name = "wasmedge.py",
+    src = "wasmedge.py",
+    visibility = [
+        "toolchains//...",
+        "//tests/...",
+    ],
+)
+
+export_file(
+    name = "wasm-micro-runtime.py",
+    src = "wasm-micro-runtime.py",
+    visibility = [
+        "toolchains//...",
+        "//tests/...",
+    ],
+)
+
 filegroup(
     name = "dist_files",
     srcs = glob(["*.py"]),

--- a/adapters/wasm-micro-runtime.py
+++ b/adapters/wasm-micro-runtime.py
@@ -7,8 +7,9 @@ from typing import Dict, List, Tuple
 import importlib
 
 
-# shlex.split() splits according to shell quoting rules
-IWASM = shlex.split(os.getenv("IWASM", "iwasm"))
+# shlex.split() splits according to shell quoting rules.
+# Use posix=False on Windows to preserve backslash path separators.
+IWASM = shlex.split(os.getenv("IWASM", "iwasm"), posix=(os.name != "nt"))
 
 
 def get_name() -> str:
@@ -46,7 +47,7 @@ def compute_argv(test_path: str,
         argv += ["--env", f"{k}={v}"]
 
     for host, guest in dirs:
-        argv += ["--map-dir", f"{host}::{guest}"]  # noqa: E231
+        argv += [f"--map-dir={guest}::{host}"]  # noqa: E231
 
     argv += [test_path]
 

--- a/adapters/wasmedge.py
+++ b/adapters/wasmedge.py
@@ -7,8 +7,9 @@ from typing import Dict, List, Tuple
 import importlib
 
 
-# shlex.split() splits according to shell quoting rules
-WASMEDGE = shlex.split(os.getenv("WASMEDGE", "wasmedge"))
+# shlex.split() splits according to shell quoting rules.
+# Use posix=False on Windows to preserve backslash path separators.
+WASMEDGE = shlex.split(os.getenv("WASMEDGE", "wasmedge"), posix=(os.name != "nt"))
 
 
 def get_name() -> str:

--- a/adapters/wazero.py
+++ b/adapters/wazero.py
@@ -7,8 +7,9 @@ from typing import Dict, List, Tuple
 import importlib
 
 
-# shlex.split() splits according to shell quoting rules
-WAZERO = shlex.split(os.getenv("WAZERO", "wazero"))
+# shlex.split() splits according to shell quoting rules.
+# Use posix=False on Windows to preserve backslash path separators.
+WAZERO = shlex.split(os.getenv("WAZERO", "wazero"), posix=(os.name != "nt"))
 
 
 def get_name() -> str:

--- a/expectations/BUCK
+++ b/expectations/BUCK
@@ -16,6 +16,30 @@ export_file(
     visibility = ["PUBLIC"],
 )
 
+export_file(
+    name = "wazero_linux",
+    src = "wazero-linux.json",
+    visibility = ["PUBLIC"],
+)
+
+export_file(
+    name = "wazero_macos",
+    src = "wazero-macos.json",
+    visibility = ["PUBLIC"],
+)
+
+export_file(
+    name = "wazero_windows",
+    src = "wazero-windows.json",
+    visibility = ["PUBLIC"],
+)
+
+export_file(
+    name = "wamr_linux",
+    src = "wamr-linux.json",
+    visibility = ["PUBLIC"],
+)
+
 filegroup(
     name = "dist_files",
     srcs = glob(["*.json"]),

--- a/expectations/wamr-linux.json
+++ b/expectations/wamr-linux.json
@@ -1,0 +1,6 @@
+{
+  "WASI AssemblyScript tests [wasm32-wasip1]": {
+    "environ_get-multiple-variables": "WAMR differs for this Preview 1 AssemblyScript test",
+    "environ_sizes_get-multiple-variables": "WAMR differs for this Preview 1 AssemblyScript test"
+  }
+}

--- a/expectations/wazero-linux.json
+++ b/expectations/wazero-linux.json
@@ -1,0 +1,20 @@
+{
+  "WASI C tests [wasm32-wasip1]": {
+    "pwrite-with-append": "Wazero differs for this Preview 1 C test",
+    "sock_shutdown-not_sock": "Wazero differs for this Preview 1 C test"
+  },
+  "WASI Rust tests [wasm32-wasip1]": {
+    "dir_fd_op_failures": "Wazero differs for this Preview 1 Rust test",
+    "fd_fdstat_set_rights": "Wazero differs for this Preview 1 Rust test",
+    "overwrite_preopen": "Wazero differs for this Preview 1 Rust test",
+    "path_filestat": "Wazero differs for this Preview 1 Rust test",
+    "path_link": "Wazero differs for this Preview 1 Rust test",
+    "path_open_read_write": "Wazero differs for this Preview 1 Rust test",
+    "poll_oneoff_stdio": "Wazero differs for this Preview 1 Rust test",
+    "readlink": "Wazero differs for this Preview 1 Rust test",
+    "renumber": "Wazero differs for this Preview 1 Rust test",
+    "stdio": "Wazero differs for this Preview 1 Rust test",
+    "symlink_filestat": "Wazero differs for this Preview 1 Rust test",
+    "truncation_rights": "Wazero differs for this Preview 1 Rust test"
+  }
+}

--- a/expectations/wazero-macos.json
+++ b/expectations/wazero-macos.json
@@ -1,0 +1,20 @@
+{
+  "WASI C tests [wasm32-wasip1]": {
+    "pwrite-with-append": "Wazero differs for this Preview 1 C test",
+    "sock_shutdown-not_sock": "Wazero differs for this Preview 1 C test"
+  },
+  "WASI Rust tests [wasm32-wasip1]": {
+    "dir_fd_op_failures": "Wazero differs for this Preview 1 Rust test",
+    "fd_fdstat_set_rights": "Wazero differs for this Preview 1 Rust test",
+    "overwrite_preopen": "Wazero differs for this Preview 1 Rust test",
+    "path_filestat": "Wazero differs for this Preview 1 Rust test",
+    "path_link": "Wazero differs for this Preview 1 Rust test",
+    "path_open_read_write": "Wazero differs for this Preview 1 Rust test",
+    "poll_oneoff_stdio": "Wazero differs for this Preview 1 Rust test",
+    "readlink": "Wazero differs for this Preview 1 Rust test",
+    "renumber": "Wazero differs for this Preview 1 Rust test",
+    "stdio": "Wazero differs for this Preview 1 Rust test",
+    "symlink_filestat": "Wazero differs for this Preview 1 Rust test",
+    "truncation_rights": "Wazero differs for this Preview 1 Rust test"
+  }
+}

--- a/expectations/wazero-windows.json
+++ b/expectations/wazero-windows.json
@@ -1,0 +1,20 @@
+{
+  "WASI C tests [wasm32-wasip1]": {
+    "pwrite-with-append": "Wazero differs for this Preview 1 C test",
+    "sock_shutdown-not_sock": "Wazero differs for this Preview 1 C test"
+  },
+  "WASI Rust tests [wasm32-wasip1]": {
+    "dir_fd_op_failures": "Wazero differs for this Preview 1 Rust test",
+    "fd_fdstat_set_rights": "Wazero differs for this Preview 1 Rust test",
+    "overwrite_preopen": "Wazero differs for this Preview 1 Rust test",
+    "path_filestat": "Wazero differs for this Preview 1 Rust test",
+    "path_link": "Wazero differs for this Preview 1 Rust test",
+    "path_open_read_write": "Wazero differs for this Preview 1 Rust test",
+    "poll_oneoff_stdio": "Wazero differs for this Preview 1 Rust test",
+    "readlink": "Wazero differs for this Preview 1 Rust test",
+    "renumber": "Wazero differs for this Preview 1 Rust test",
+    "stdio": "Wazero differs for this Preview 1 Rust test",
+    "symlink_filestat": "Wazero differs for this Preview 1 Rust test",
+    "truncation_rights": "Wazero differs for this Preview 1 Rust test"
+  }
+}

--- a/justfile
+++ b/justfile
@@ -53,6 +53,10 @@ test-rust wasi="p1" runtime="wasmtime":
 test-all:
     {{buck}} test //tests/...
 
+# Run non-Wasmtime Buck runtime suites.
+test-extra-runtimes:
+    {{buck}} test //tests:wazero //tests:wasmedge //tests:wamr
+
 # Run one Buck test target, e.g. `just test-one //tests/c:lseek_wasmtime`.
 test-one target:
     {{buck}} test {{target}}

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -1,5 +1,6 @@
 load("//tools:conformance.bzl", "wasi_suite")
 load("//tools:dist.bzl", "wasi_dist")
+load("//tools:runtime.bzl", "WAMR_COMPATIBLE_WITH")
 
 wasi_suite(
     name = "wasmtime",
@@ -9,6 +10,34 @@ wasi_suite(
         "//tests/rust/wasm32-wasip3:wasmtime",
         "//tests/assemblyscript/wasm32-wasip1:wasmtime",
     ],
+)
+
+wasi_suite(
+    name = "wazero",
+    tests = [
+        "//tests/c:wazero",
+        "//tests/rust/wasm32-wasip1:wazero",
+        "//tests/assemblyscript/wasm32-wasip1:wazero",
+    ],
+)
+
+wasi_suite(
+    name = "wasmedge",
+    tests = [
+        "//tests/c:wasmedge",
+        "//tests/rust/wasm32-wasip1:wasmedge",
+        "//tests/assemblyscript/wasm32-wasip1:wasmedge",
+    ],
+)
+
+wasi_suite(
+    name = "wamr",
+    tests = [
+        "//tests/c:wamr",
+        "//tests/rust/wasm32-wasip1:wamr",
+        "//tests/assemblyscript/wasm32-wasip1:wamr",
+    ],
+    target_compatible_with = WAMR_COMPATIBLE_WITH,
 )
 
 wasi_dist(

--- a/tests/assemblyscript/wasm32-wasip1/BUCK
+++ b/tests/assemblyscript/wasm32-wasip1/BUCK
@@ -1,5 +1,6 @@
 load(":defs.bzl", "asc_test", "asc_tests_for_runtime")
 load("//tools:conformance.bzl", "wasi_manifest", "wasi_suite")
+load("//tools:runtime.bzl", "WAMR_COMPATIBLE_WITH")
 
 _WASI_ASSEMBLYSCRIPT = wasi_manifest(
     name = "WASI AssemblyScript tests",
@@ -22,15 +23,48 @@ _ASSEMBLYSCRIPT_TESTS = [
     asc_test("proc_exit-failure"),
 ]
 
-_WASMTIME_TESTS = asc_tests_for_runtime(
-    tests = _ASSEMBLYSCRIPT_TESTS,
+wasi_suite(
     name = "wasmtime",
-    runtime = "toolchains//:wasmtime_runtime",
-    manifest = _WASI_ASSEMBLYSCRIPT,
+    tests = asc_tests_for_runtime(
+        tests = _ASSEMBLYSCRIPT_TESTS,
+        name = "wasmtime",
+        runtime = "toolchains//:wasmtime_runtime",
+        manifest = _WASI_ASSEMBLYSCRIPT,
+    ),
+    visibility = ["//tests/..."],
 )
 
 wasi_suite(
-    name = "wasmtime",
-    tests = _WASMTIME_TESTS,
+    name = "wazero",
+    tests = asc_tests_for_runtime(
+        tests = _ASSEMBLYSCRIPT_TESTS,
+        name = "wazero",
+        runtime = "toolchains//:wazero_runtime",
+        manifest = _WASI_ASSEMBLYSCRIPT,
+    ),
+    visibility = ["//tests/..."],
+)
+
+wasi_suite(
+    name = "wasmedge",
+    tests = asc_tests_for_runtime(
+        tests = _ASSEMBLYSCRIPT_TESTS,
+        name = "wasmedge",
+        runtime = "toolchains//:wasmedge_runtime",
+        manifest = _WASI_ASSEMBLYSCRIPT,
+    ),
+    visibility = ["//tests/..."],
+)
+
+wasi_suite(
+    name = "wamr",
+    tests = asc_tests_for_runtime(
+        tests = _ASSEMBLYSCRIPT_TESTS,
+        name = "wamr",
+        runtime = "toolchains//:wamr_runtime",
+        manifest = _WASI_ASSEMBLYSCRIPT,
+        target_compatible_with = WAMR_COMPATIBLE_WITH,
+    ),
+    target_compatible_with = WAMR_COMPATIBLE_WITH,
     visibility = ["//tests/..."],
 )

--- a/tests/assemblyscript/wasm32-wasip1/defs.bzl
+++ b/tests/assemblyscript/wasm32-wasip1/defs.bzl
@@ -15,7 +15,7 @@ def _asc_artifact(name):
         visibility = ["//tests/..."],
     )
 
-def _asc_test_for_runtime(test, name, runtime, manifest):
+def _asc_test_for_runtime(test, name, runtime, manifest, target_compatible_with = None):
     test_target = "{}_{}".format(test.name, name)
 
     wasi_test(
@@ -24,6 +24,7 @@ def _asc_test_for_runtime(test, name, runtime, manifest):
         runtime = runtime,
         manifest = manifest,
         config = test.config,
+        target_compatible_with = target_compatible_with,
         visibility = ["//tests/..."],
     )
 
@@ -39,13 +40,14 @@ def asc_test(name, conf = None):
         name = name,
     )
 
-def asc_tests_for_runtime(tests, name, runtime, manifest):
+def asc_tests_for_runtime(tests, name, runtime, manifest, target_compatible_with = None):
     return [
         _asc_test_for_runtime(
             test,
             name = name,
             runtime = runtime,
             manifest = manifest,
+            target_compatible_with = target_compatible_with,
         )
         for test in tests
     ]

--- a/tests/c/BUCK
+++ b/tests/c/BUCK
@@ -1,5 +1,6 @@
 load(":defs.bzl", "c_test", "c_tests_for_runtime")
 load("//tools:conformance.bzl", "wasi_manifest", "wasi_suite")
+load("//tools:runtime.bzl", "WAMR_COMPATIBLE_WITH")
 
 _WASI_C = wasi_manifest(
     name = "WASI C tests",
@@ -24,15 +25,48 @@ _C_TESTS = [
     c_test("stat-dev-ino"),
 ]
 
-_WASMTIME_TESTS = c_tests_for_runtime(
-    tests = _C_TESTS,
+wasi_suite(
     name = "wasmtime",
-    runtime = "toolchains//:wasmtime_runtime",
-    manifest = _WASI_C,
+    tests = c_tests_for_runtime(
+        tests = _C_TESTS,
+        name = "wasmtime",
+        runtime = "toolchains//:wasmtime_runtime",
+        manifest = _WASI_C,
+    ),
+    visibility = ["//tests/..."],
 )
 
 wasi_suite(
-    name = "wasmtime",
-    tests = _WASMTIME_TESTS,
+    name = "wazero",
+    tests = c_tests_for_runtime(
+        tests = _C_TESTS,
+        name = "wazero",
+        runtime = "toolchains//:wazero_runtime",
+        manifest = _WASI_C,
+    ),
+    visibility = ["//tests/..."],
+)
+
+wasi_suite(
+    name = "wasmedge",
+    tests = c_tests_for_runtime(
+        tests = _C_TESTS,
+        name = "wasmedge",
+        runtime = "toolchains//:wasmedge_runtime",
+        manifest = _WASI_C,
+    ),
+    visibility = ["//tests/..."],
+)
+
+wasi_suite(
+    name = "wamr",
+    tests = c_tests_for_runtime(
+        tests = _C_TESTS,
+        name = "wamr",
+        runtime = "toolchains//:wamr_runtime",
+        manifest = _WASI_C,
+        target_compatible_with = WAMR_COMPATIBLE_WITH,
+    ),
+    target_compatible_with = WAMR_COMPATIBLE_WITH,
     visibility = ["//tests/..."],
 )

--- a/tests/c/defs.bzl
+++ b/tests/c/defs.bzl
@@ -24,7 +24,7 @@ def _c_artifact(name):
         visibility = ["//tests/..."],
     )
 
-def _c_test_for_runtime(test, name, runtime, manifest):
+def _c_test_for_runtime(test, name, runtime, manifest, target_compatible_with = None):
     test_target = "{}_{}".format(test.name, name)
 
     wasi_test(
@@ -34,6 +34,7 @@ def _c_test_for_runtime(test, name, runtime, manifest):
         manifest = manifest,
         config = test.config,
         fixture_dirs = test.fixture_dirs,
+        target_compatible_with = target_compatible_with,
         visibility = ["//tests/..."],
     )
 
@@ -51,13 +52,14 @@ def c_test(name, conf = None, dirs = None):
         fixture_dirs = fixture_dirs,
     )
 
-def c_tests_for_runtime(tests, name, runtime, manifest):
+def c_tests_for_runtime(tests, name, runtime, manifest, target_compatible_with = None):
     return [
         _c_test_for_runtime(
             test,
             name = name,
             runtime = runtime,
             manifest = manifest,
+            target_compatible_with = target_compatible_with,
         )
         for test in tests
     ]

--- a/tests/rust/wasm32-wasip1/BUCK
+++ b/tests/rust/wasm32-wasip1/BUCK
@@ -1,5 +1,6 @@
 load(":defs.bzl", "rust_test", "rust_tests_for_runtime")
 load("//tools:conformance.bzl", "wasi_manifest", "wasi_suite")
+load("//tools:runtime.bzl", "WAMR_COMPATIBLE_WITH")
 
 _WASI_RUST = wasi_manifest(
     name = "WASI Rust tests",
@@ -82,15 +83,48 @@ _RUST_TESTS = [
     rust_test("unlink_file_trailing_slashes", deps = _RUST_DEPS),
 ]
 
-_WASMTIME_TESTS = rust_tests_for_runtime(
-    tests = _RUST_TESTS,
+wasi_suite(
     name = "wasmtime",
-    runtime = "toolchains//:wasmtime_runtime",
-    manifest = _WASI_RUST,
+    tests = rust_tests_for_runtime(
+        tests = _RUST_TESTS,
+        name = "wasmtime",
+        runtime = "toolchains//:wasmtime_runtime",
+        manifest = _WASI_RUST,
+    ),
+    visibility = ["//tests/..."],
 )
 
 wasi_suite(
-    name = "wasmtime",
-    tests = _WASMTIME_TESTS,
+    name = "wazero",
+    tests = rust_tests_for_runtime(
+        tests = _RUST_TESTS,
+        name = "wazero",
+        runtime = "toolchains//:wazero_runtime",
+        manifest = _WASI_RUST,
+    ),
+    visibility = ["//tests/..."],
+)
+
+wasi_suite(
+    name = "wasmedge",
+    tests = rust_tests_for_runtime(
+        tests = _RUST_TESTS,
+        name = "wasmedge",
+        runtime = "toolchains//:wasmedge_runtime",
+        manifest = _WASI_RUST,
+    ),
+    visibility = ["//tests/..."],
+)
+
+wasi_suite(
+    name = "wamr",
+    tests = rust_tests_for_runtime(
+        tests = _RUST_TESTS,
+        name = "wamr",
+        runtime = "toolchains//:wamr_runtime",
+        manifest = _WASI_RUST,
+        target_compatible_with = WAMR_COMPATIBLE_WITH,
+    ),
+    target_compatible_with = WAMR_COMPATIBLE_WITH,
     visibility = ["//tests/..."],
 )

--- a/tests/rust/wasm32-wasip1/defs.bzl
+++ b/tests/rust/wasm32-wasip1/defs.bzl
@@ -38,7 +38,7 @@ def _rust_artifact(name, deps):
         visibility = ["//tests/..."],
     )
 
-def _rust_test_for_runtime(test, name, runtime, manifest):
+def _rust_test_for_runtime(test, name, runtime, manifest, target_compatible_with = None):
     test_target = "{}_{}".format(test.name, name)
 
     wasi_test(
@@ -49,6 +49,7 @@ def _rust_test_for_runtime(test, name, runtime, manifest):
         config = test.config,
         fixture_dirs = test.fixture_dirs,
         test_name = test.name,
+        target_compatible_with = target_compatible_with,
         visibility = ["//tests/..."],
     )
 
@@ -66,13 +67,14 @@ def rust_test(name, conf = None, dirs = None, deps = []):
         name = name,
     )
 
-def rust_tests_for_runtime(tests, name, runtime, manifest):
+def rust_tests_for_runtime(tests, name, runtime, manifest, target_compatible_with = None):
     return [
         _rust_test_for_runtime(
             test,
             name = name,
             runtime = runtime,
             manifest = manifest,
+            target_compatible_with = target_compatible_with,
         )
         for test in tests
     ]

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -4,8 +4,8 @@ load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//toolchains:python.bzl", "remote_python_toolchain")
 load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
 load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
-load("@root//tools:runtime.bzl", "wasi_runtime")
-load(":runtimes.bzl", "download_wasmtime_runtime")
+load("@root//tools:runtime.bzl", "WAMR_COMPATIBLE_WITH", "wasi_runtime")
+load(":runtimes.bzl", "download_wamr_runtime", "download_wasmedge_runtime", "download_wasmtime_runtime", "download_wazero_runtime")
 load(
     "@wasmono//:defs.bzl",
     "asc_toolchain",
@@ -87,6 +87,13 @@ wasm_tools_toolchain(name = "wasm_tools", distribution = ":wasm_tools_dist", vis
 # Runtime distributions and descriptors. The descriptor is what `wasi_test`
 # consumes, so adding a runtime means adding another descriptor target here.
 download_wasmtime_runtime(name = "wasmtime_dist", version = "45.0.0")
+download_wasmedge_runtime(name = "wasmedge_dist", version = "0.17.0")
+download_wazero_runtime(name = "wazero_dist", version = "1.12.0")
+download_wamr_runtime(
+    name = "wamr_dist",
+    version = "2.4.4",
+    target_compatible_with = WAMR_COMPATIBLE_WITH,
+)
 
 wasi_runtime(
     name = "wasmtime_runtime",
@@ -99,6 +106,40 @@ wasi_runtime(
     runtime = ":wasmtime_dist",
     runtime_env_var = "WASMTIME",
     labels = ["wasmtime"],
+    visibility = ["PUBLIC"],
+)
+
+wasi_runtime(
+    name = "wazero_runtime",
+    adapter = "root//adapters:wazero.py",
+    exclude_filter = select({
+        "config//os:macos": "root//expectations:wazero_macos",
+        "config//os:windows": "root//expectations:wazero_windows",
+        "DEFAULT": "root//expectations:wazero_linux",
+    }),
+    runtime = ":wazero_dist",
+    runtime_env_var = "WAZERO",
+    labels = ["wazero"],
+    visibility = ["PUBLIC"],
+)
+
+wasi_runtime(
+    name = "wasmedge_runtime",
+    adapter = "root//adapters:wasmedge.py",
+    runtime = ":wasmedge_dist",
+    runtime_env_var = "WASMEDGE",
+    labels = ["wasmedge"],
+    visibility = ["PUBLIC"],
+)
+
+wasi_runtime(
+    name = "wamr_runtime",
+    adapter = "root//adapters:wasm-micro-runtime.py",
+    exclude_filter = "root//expectations:wamr_linux",
+    runtime = ":wamr_dist",
+    runtime_env_var = "IWASM",
+    labels = ["wamr"],
+    target_compatible_with = WAMR_COMPATIBLE_WITH,
     visibility = ["PUBLIC"],
 )
 

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -5,7 +5,17 @@ load("@prelude//toolchains:python.bzl", "remote_python_toolchain")
 load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
 load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 load("@root//tools:runtime.bzl", "WAMR_COMPATIBLE_WITH", "wasi_runtime")
-load(":runtimes.bzl", "download_wamr_runtime", "download_wasmedge_runtime", "download_wasmtime_runtime", "download_wazero_runtime")
+load(
+    ":runtimes.bzl",
+    "DEFAULT_WAMR_VERSION",
+    "DEFAULT_WASMEDGE_VERSION",
+    "DEFAULT_WASMTIME_VERSION",
+    "DEFAULT_WAZERO_VERSION",
+    "download_wamr_runtime",
+    "download_wasmedge_runtime",
+    "download_wasmtime_runtime",
+    "download_wazero_runtime",
+)
 load(
     "@wasmono//:defs.bzl",
     "asc_toolchain",
@@ -86,12 +96,12 @@ wasm_tools_toolchain(name = "wasm_tools", distribution = ":wasm_tools_dist", vis
 
 # Runtime distributions and descriptors. The descriptor is what `wasi_test`
 # consumes, so adding a runtime means adding another descriptor target here.
-download_wasmtime_runtime(name = "wasmtime_dist", version = "45.0.0")
-download_wasmedge_runtime(name = "wasmedge_dist", version = "0.17.0")
-download_wazero_runtime(name = "wazero_dist", version = "1.12.0")
+download_wasmtime_runtime(name = "wasmtime_dist", version = DEFAULT_WASMTIME_VERSION)
+download_wasmedge_runtime(name = "wasmedge_dist", version = DEFAULT_WASMEDGE_VERSION)
+download_wazero_runtime(name = "wazero_dist", version = DEFAULT_WAZERO_VERSION)
 download_wamr_runtime(
     name = "wamr_dist",
-    version = "2.4.4",
+    version = DEFAULT_WAMR_VERSION,
     target_compatible_with = WAMR_COMPATIBLE_WITH,
 )
 

--- a/toolchains/releases.bzl
+++ b/toolchains/releases.bzl
@@ -49,3 +49,73 @@ WASMTIME_RELEASES = {
         },
     },
 }
+
+WAMR_RELEASES = {
+    "2.4.4": {
+        "x86_64-linux": {
+            "url": "https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-2.4.4/iwasm-2.4.4-x86_64-ubuntu-22.04.tar.gz",
+            "shasum": "ec60ff8daed26319dfc4371843c56ac2dfadd20e2218cbbca97aecb8b390b7a8",
+            "binary": "iwasm",
+        },
+    },
+}
+
+WAZERO_RELEASES = {
+    "1.12.0": {
+        "aarch64-linux": {
+            "url": "https://github.com/wazero/wazero/releases/download/v1.12.0/wazero_1.12.0_linux_arm64.tar.gz",
+            "shasum": "b5e5105a8bc4817a117e52402713f0628ebe13ecec5c4e63d541c430ca9bf259",
+            "binary": "wazero",
+        },
+        "aarch64-macos": {
+            "url": "https://github.com/wazero/wazero/releases/download/v1.12.0/wazero_1.12.0_darwin_arm64.tar.gz",
+            "shasum": "c9e811bb8638163a294de8579923a4ce759846dc04f964468855a23e69bbe73c",
+            "binary": "wazero",
+        },
+        "x86_64-linux": {
+            "url": "https://github.com/wazero/wazero/releases/download/v1.12.0/wazero_1.12.0_linux_amd64.tar.gz",
+            "shasum": "88019896950340e8839b94af0510b248c3400d8d8f4a9b335dcaad93ac0484ff",
+            "binary": "wazero",
+        },
+        "x86_64-macos": {
+            "url": "https://github.com/wazero/wazero/releases/download/v1.12.0/wazero_1.12.0_darwin_amd64.tar.gz",
+            "shasum": "4a142b30ab0c7cfeae3fb453c5d2f3beca5af823d5aeeb4c0de458f89e9d5bb8",
+            "binary": "wazero",
+        },
+        "x86_64-windows": {
+            "url": "https://github.com/wazero/wazero/releases/download/v1.12.0/wazero_1.12.0_windows_amd64.zip",
+            "shasum": "32342e7e6ffc6d1016ae35e9e15479ef718076f27afdad1e89bb1bb6796efeee",
+            "binary": "wazero",
+        },
+    },
+}
+
+WASMEDGE_RELEASES = {
+    "0.17.0": {
+        "aarch64-linux": {
+            "url": "https://github.com/WasmEdge/WasmEdge/releases/download/0.17.0/WasmEdge-0.17.0-manylinux_2_28_aarch64.tar.gz",
+            "shasum": "6d3aa5a43fd0998b11812e99b46e90a282f3caaacc9cfef14b67f3438b63e804",
+            "binary": "bin/wasmedge",
+        },
+        "aarch64-macos": {
+            "url": "https://github.com/WasmEdge/WasmEdge/releases/download/0.17.0/WasmEdge-0.17.0-darwin_arm64.tar.gz",
+            "shasum": "ae97ff792ac1bf7bcf703b20926b9bac168e5b6260930d13a156dc19e68a67c5",
+            "binary": "bin/wasmedge",
+        },
+        "x86_64-linux": {
+            "url": "https://github.com/WasmEdge/WasmEdge/releases/download/0.17.0/WasmEdge-0.17.0-manylinux_2_28_x86_64.tar.gz",
+            "shasum": "5d8165559c553eacc9b87db1799c2204e056db8609bedbf61eb29f8a21a42993",
+            "binary": "bin/wasmedge",
+        },
+        "x86_64-macos": {
+            "url": "https://github.com/WasmEdge/WasmEdge/releases/download/0.17.0/WasmEdge-0.17.0-darwin_x86_64.tar.gz",
+            "shasum": "5742f7d19bbdb983f4df57114b085f908bae06f705ea3e167f802a66bd9e0342",
+            "binary": "bin/wasmedge",
+        },
+        "x86_64-windows": {
+            "url": "https://github.com/WasmEdge/WasmEdge/releases/download/0.17.0/WasmEdge-0.17.0-windows.zip",
+            "shasum": "9d38f0f8a8211c9f4a355e7c7e825e4545f3a12908de7f4eec2aa8e84fb593a6",
+            "binary": "bin/wasmedge",
+        },
+    },
+}

--- a/toolchains/runtimes.bzl
+++ b/toolchains/runtimes.bzl
@@ -3,6 +3,11 @@
 load("@wasmono//:defs.bzl", "host_arch", "host_os")
 load(":releases.bzl", "WAMR_RELEASES", "WASMEDGE_RELEASES", "WASMTIME_RELEASES", "WAZERO_RELEASES")
 
+DEFAULT_WAMR_VERSION = "2.4.4"
+DEFAULT_WASMEDGE_VERSION = "0.17.0"
+DEFAULT_WASMTIME_VERSION = "45.0.0"
+DEFAULT_WAZERO_VERSION = "1.12.0"
+
 def _runtime_platform() -> str:
     return "{}-{}".format(host_arch(), host_os())
 
@@ -86,21 +91,21 @@ def _download_runtime(
         **kwargs
     )
 
-def download_wasmtime_runtime(name: str, version: str = "45.0.0"):
+def download_wasmtime_runtime(name: str, version: str = DEFAULT_WASMTIME_VERSION):
     """Download a prebuilt Wasmtime runtime."""
     _download_runtime(name, WASMTIME_RELEASES, "wasmtime", version)
 
 def download_wamr_runtime(
         name: str,
-        version: str = "2.4.4",
+        version: str = DEFAULT_WAMR_VERSION,
         target_compatible_with: list[str] = []):
     """Download a prebuilt WAMR (iwasm) runtime."""
     _download_runtime(name, WAMR_RELEASES, "wamr", version, target_compatible_with)
 
-def download_wazero_runtime(name: str, version: str = "1.12.0"):
+def download_wazero_runtime(name: str, version: str = DEFAULT_WAZERO_VERSION):
     """Download a prebuilt Wazero runtime."""
     _download_runtime(name, WAZERO_RELEASES, "wazero", version)
 
-def download_wasmedge_runtime(name: str, version: str = "0.17.0"):
+def download_wasmedge_runtime(name: str, version: str = DEFAULT_WASMEDGE_VERSION):
     """Download a prebuilt WasmEdge runtime."""
     _download_runtime(name, WASMEDGE_RELEASES, "wasmedge", version)

--- a/toolchains/runtimes.bzl
+++ b/toolchains/runtimes.bzl
@@ -1,12 +1,12 @@
 """Download rules for WASI runtime binaries used by the test suite."""
 
 load("@wasmono//:defs.bzl", "host_arch", "host_os")
-load(":releases.bzl", "WASMTIME_RELEASES")
+load(":releases.bzl", "WAMR_RELEASES", "WASMEDGE_RELEASES", "WASMTIME_RELEASES", "WAZERO_RELEASES")
 
 def _runtime_platform() -> str:
     return "{}-{}".format(host_arch(), host_os())
 
-def _runtime_release(releases, runtime_name: str, version: str):
+def _runtime_release(releases, runtime_name: str, version: str, target_compatible_with: list[str] = []):
     platform = _runtime_platform()
     if version not in releases:
         fail("Unknown {} version '{}'. Available: {}".format(
@@ -16,6 +16,10 @@ def _runtime_release(releases, runtime_name: str, version: str):
         ))
 
     release = releases[version]
+    if platform not in release and target_compatible_with:
+        for fallback in release.values():
+            return fallback
+
     if platform not in release:
         fail("No {} release for platform '{}'. Available: {}".format(
             runtime_name,
@@ -55,13 +59,22 @@ _runtime_distribution = rule(
     },
 )
 
-def _download_runtime(name: str, releases, runtime_name: str, version: str):
-    release = _runtime_release(releases, runtime_name, version)
+def _download_runtime(
+        name: str,
+        releases,
+        runtime_name: str,
+        version: str,
+        target_compatible_with: list[str] = []):
+    release = _runtime_release(releases, runtime_name, version, target_compatible_with)
+    kwargs = {}
+    if target_compatible_with:
+        kwargs["target_compatible_with"] = target_compatible_with
 
     native.http_archive(
         name = name + "-archive",
         urls = [release["url"]],
         sha256 = release["shasum"],
+        **kwargs
     )
 
     _runtime_distribution(
@@ -70,8 +83,24 @@ def _download_runtime(name: str, releases, runtime_name: str, version: str):
         binary = release["binary"] + (".exe" if host_os() == "windows" else ""),
         prefix = release.get("prefix", ""),
         visibility = ["PUBLIC"],
+        **kwargs
     )
 
 def download_wasmtime_runtime(name: str, version: str = "45.0.0"):
     """Download a prebuilt Wasmtime runtime."""
     _download_runtime(name, WASMTIME_RELEASES, "wasmtime", version)
+
+def download_wamr_runtime(
+        name: str,
+        version: str = "2.4.4",
+        target_compatible_with: list[str] = []):
+    """Download a prebuilt WAMR (iwasm) runtime."""
+    _download_runtime(name, WAMR_RELEASES, "wamr", version, target_compatible_with)
+
+def download_wazero_runtime(name: str, version: str = "1.12.0"):
+    """Download a prebuilt Wazero runtime."""
+    _download_runtime(name, WAZERO_RELEASES, "wazero", version)
+
+def download_wasmedge_runtime(name: str, version: str = "0.17.0"):
+    """Download a prebuilt WasmEdge runtime."""
+    _download_runtime(name, WASMEDGE_RELEASES, "wasmedge", version)

--- a/tools/conformance.bzl
+++ b/tools/conformance.bzl
@@ -151,6 +151,7 @@ def wasi_test(
         exclude_filter = None,
         test_name = None,
         labels = [],
+        target_compatible_with = None,
         visibility = None):
     """Run one Buck-built wasm artifact against one WASI runtime.
 
@@ -165,9 +166,12 @@ def wasi_test(
         exclude_filter: Optional runner exclude filter overriding the runtime default.
         test_name: Optional runner/dist test name; inferred from `wasm` labels.
         labels: Extra Buck test labels appended to manifest labels.
+        target_compatible_with: Optional Buck constraints required for this test target.
         visibility: Optional Buck visibility.
     """
     kwargs = {}
+    if target_compatible_with != None:
+        kwargs["target_compatible_with"] = target_compatible_with
     if visibility != None:
         kwargs["visibility"] = visibility
 
@@ -221,9 +225,15 @@ _wasi_test_suite_rule = rule(
     },
 )
 
-def wasi_suite(name: str, tests: list[str], visibility = None):
+def wasi_suite(
+        name: str,
+        tests: list[str],
+        target_compatible_with = None,
+        visibility = None):
     """Group WASI tests for `buck2 test` and aggregate metadata for `wasi_dist`."""
     kwargs = {}
+    if target_compatible_with != None:
+        kwargs["target_compatible_with"] = target_compatible_with
     if visibility != None:
         kwargs["visibility"] = visibility
 

--- a/tools/runtime.bzl
+++ b/tools/runtime.bzl
@@ -22,6 +22,11 @@ WasiRuntimeInfo = provider(
     },
 )
 
+WAMR_COMPATIBLE_WITH = [
+    "config//os/constraints:linux",
+    "config//cpu/constraints:x86_64",
+]
+
 def _wasi_runtime_impl(ctx: AnalysisContext) -> list[Provider]:
     return [
         DefaultInfo(),


### PR DESCRIPTION
Add Buck2 runtime descriptors for Wazero, WasmEdge, and WAMR, including release metadata, adapters, runtime suites, and expectation filters.

This patch skips pywasm because it would mostly be a large expectation file around known runtime limitations: it fails 47/72.

It is now possible to run something like:

```
just test-rust p1 <wamr|wazero|wasmedge|wasmtime>
```