### PR TITLE
feat(ci): use buck2 for daily ci tests

### DIFF
--- a/.github/workflows/daily-runtime-validation.yml
+++ b/.github/workflows/daily-runtime-validation.yml
@@ -32,25 +32,16 @@ jobs:
       - name: Install Rust WASI targets
         run: rustup target add wasm32-wasip1 wasm32-wasip2
 
-      - name: Configure Buck2 launcher on Windows
-        if: runner.os == 'Windows'
-        run: |
-          echo 'BUCK2=dotslash ./buck2' >> "$GITHUB_ENV"
-          echo 'MSYS2_ARG_CONV_EXCL=//' >> "$GITHUB_ENV"
-
       - name: Run all tests
+        env:
+          MSYS_NO_PATHCONV: "1"
+          MSYS2_ARG_CONV_EXCL: "*"
         run: just test
 
   other-runtimes:
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,12 +57,5 @@ jobs:
       - name: Install Rust WASI targets
         run: rustup target add wasm32-wasip1 wasm32-wasip2
 
-      - name: Configure Buck2 launcher on Windows
-        if: runner.os == 'Windows'
-        run: |
-          echo 'BUCK2=dotslash ./buck2' >> "$GITHUB_ENV"
-          echo 'MSYS2_ARG_CONV_EXCL=//' >> "$GITHUB_ENV"
-
       - name: Run extra Buck runtime tests
-        if: runner.os == 'Linux'
         run: just test-extra-runtimes

--- a/.github/workflows/daily-runtime-validation.yml
+++ b/.github/workflows/daily-runtime-validation.yml
@@ -28,10 +28,8 @@ jobs:
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: just
-      - name: install dotslash
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
-        with:
-          tool: dotslash
+
+      - uses: facebook/install-dotslash@5f505c7478ed90c86b492133b43dca875a3c885a
 
       - name: Install Rust WASI targets
         run: rustup target add wasm32-wasip1 wasm32-wasip2
@@ -57,10 +55,7 @@ jobs:
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: just
-      - name: install dotslash
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
-        with:
-          tool: dotslash
+      - uses: facebook/install-dotslash@5f505c7478ed90c86b492133b43dca875a3c885a
 
       - name: Install Rust WASI targets
         run: rustup target add wasm32-wasip1 wasm32-wasip2

--- a/.github/workflows/daily-runtime-validation.yml
+++ b/.github/workflows/daily-runtime-validation.yml
@@ -24,10 +24,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Install Buck2 helper tools
-        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
+      - name: install just
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: dotslash,just
+          tool: just
+      - name: install dotslash
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: dotslash
 
       - name: Install Rust WASI targets
         run: rustup target add wasm32-wasip1 wasm32-wasip2
@@ -49,10 +53,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Install Buck2 helper tools
-        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
+      - name: install just
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: dotslash,just
+          tool: just
+      - name: install dotslash
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: dotslash
 
       - name: Install Rust WASI targets
         run: rustup target add wasm32-wasip1 wasm32-wasip2

--- a/.github/workflows/daily-runtime-validation.yml
+++ b/.github/workflows/daily-runtime-validation.yml
@@ -4,85 +4,74 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions: {}
+
 jobs:
-  run_tests:
+  wasmtime:
+    runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: read
     strategy:
-      max-parallel: 1
       matrix:
-        runtime: [wasmtime, wasm-micro-runtime, wazero, wasmedge, pywasm]
-    runs-on: ubuntu-latest
+        platform:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
-          ref: prod/testsuite-base
 
-      - name: Initialize Python environment
-        uses: actions/setup-python@v4
+      - name: Install Buck2 helper tools
+        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
         with:
-          python-version: '3.12'
-          cache: pip
+          tool: dotslash,just
 
-      - name: Install dependencies
-        working-directory: test-runner
-        run: pip install -r requirements.txt
+      - name: Install Rust WASI targets
+        run: rustup target add wasm32-wasip1 wasm32-wasip2
 
-      - name: Install wasmtime
-        if: matrix.runtime == 'wasmtime'
-        uses: bytecodealliance/actions/wasmtime/setup@v1
+      - name: Configure Buck2 launcher on Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo 'BUCK2=dotslash ./buck2' >> "$GITHUB_ENV"
+          echo 'MSYS2_ARG_CONV_EXCL=//' >> "$GITHUB_ENV"
+
+      - name: Run all tests
+        run: just test
+
+  other-runtimes:
+    runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          version: dev
+          persist-credentials: false
+          fetch-depth: 0
 
-      - name: Install WASM Micro Runtime
-        if: matrix.runtime == 'wasm-micro-runtime'
+      - name: Install Buck2 helper tools
+        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
+        with:
+          tool: dotslash,just
+
+      - name: Install Rust WASI targets
+        run: rustup target add wasm32-wasip1 wasm32-wasip2
+
+      - name: Configure Buck2 launcher on Windows
+        if: runner.os == 'Windows'
         run: |
-          git clone https://github.com/bytecodealliance/wasm-micro-runtime.git
-          cd wasm-micro-runtime/product-mini/platforms/linux/
-          mkdir build && cd build
-          cmake .. -DWAMR_BUILD_BULK_MEMORY=1 -DWAMR_BUILD_SHARED_MEMORY=1
-          make
-          echo "$GITHUB_WORKSPACE/wasm-micro-runtime/product-mini/platforms/linux/build" >> $GITHUB_PATH
+          echo 'BUCK2=dotslash ./buck2' >> "$GITHUB_ENV"
+          echo 'MSYS2_ARG_CONV_EXCL=//' >> "$GITHUB_ENV"
 
-      - name: Install WasmEdge
-        if: matrix.runtime == 'wasmedge'
-        run: |
-          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash  -s -- -p ./wasmedge-install
-          echo "$GITHUB_WORKSPACE/wasmedge-install/bin/" >> $GITHUB_PATH
-
-      - name: Install wazero
-        if: matrix.runtime == 'wazero'
-        run: |
-          git clone https://github.com/tetratelabs/wazero.git
-          cd wazero
-          go install ./cmd/wazero
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
-      - name: Install pywasm
-        if: matrix.runtime == 'pywasm'
-        run: |
-          pip install pywasm
-
-      - name: Get current timestamp
-        run: echo "date=$(date +'%Y-%m-%d_%H_%M')" >> $GITHUB_ENV
-
-      - name: Run tests on ${{ matrix.runtime }}
-        continue-on-error: true
-        run: |
-          ./run-tests \
-            -r ./adapters/${{ matrix.runtime }}.py \
-            --verbose \
-            --json-output-location results.json
-
-      - name: Configure git
-        uses: ./.github/actions/git-config
-
-      - name: Upload test results
-        run: |
-          git checkout prod/daily-test-results
-          mkdir -p results/${{ matrix.runtime }}
-          cp results.json results/${{ matrix.runtime }}/${{ env.date }}.json
-          cp results.json results/${{ matrix.runtime }}/latest.json
-          git add results
-          git commit -m 'Update daily test results for ${{ matrix.runtime }}'
-          git push
+      - name: Run extra Buck runtime tests
+        if: runner.os == 'Linux'
+        run: just test-extra-runtimes

--- a/.github/workflows/daily-test-update.yml
+++ b/.github/workflows/daily-test-update.yml
@@ -1,18 +1,23 @@
 name: Daily test update
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: 0 0 * * *
-  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   update_tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: prod/testsuite-all
 
       - name: Configure git

--- a/justfile
+++ b/justfile
@@ -6,76 +6,95 @@ _default:
     @just --list
 
 # Pass arbitrary arguments through to buck2.
+[group('meta')]
 buck *args:
     {{buck}} {{args}}
 
 # List Buck targets in the repository.
+[group('meta')]
 targets:
     {{buck}} targets //...
 
-# Build all Buck targets in the repository.
-build:
-    {{buck}} build //...
-
-# Build one C runtime suite.
-build-c runtime="wasmtime":
-    {{buck}} build //tests/c:{{runtime}}
-
-# Build one AssemblyScript runtime suite.
-build-asc runtime="wasmtime":
-    {{buck}} build //tests/assemblyscript/wasm32-wasip1:{{runtime}}
-
-# Build one Rust runtime suite. Use `p1` or `p3`.
-build-rust wasi="p1" runtime="wasmtime":
-    {{buck}} build //tests/rust/wasm32-wasi{{wasi}}:{{runtime}}
-
-# Build the distribution archive.
-dist:
-    {{buck}} build --show-output //tests:dist
-
-# Run the Wasmtime Buck tests.
-test:
-    {{buck}} test //tests:wasmtime
-
-# Run one C runtime suite.
-test-c runtime="wasmtime":
-    {{buck}} test //tests/c:{{runtime}}
-
-# Run one AssemblyScript runtime suite.
-test-asc runtime="wasmtime":
-    {{buck}} test //tests/assemblyscript/wasm32-wasip1:{{runtime}}
-
-# Run one Rust runtime suite. Use `p1` or `p3`.
-test-rust wasi="p1" runtime="wasmtime":
-    {{buck}} test //tests/rust/wasm32-wasi{{wasi}}:{{runtime}}
-
-# Run all Buck tests under //tests.
-test-all:
-    {{buck}} test //tests/...
-
-# Run non-Wasmtime Buck runtime suites.
-test-extra-runtimes:
-    {{buck}} test //tests:wazero //tests:wasmedge //tests:wamr
-
-# Run one Buck test target, e.g. `just test-one //tests/c:lseek_wasmtime`.
-test-one target:
-    {{buck}} test {{target}}
+# Remove Buck outputs.
+[group('meta')]
+clean:
+    {{buck}} clean
 
 # Run every lint recipe.
+[group('check')]
 lint: lint-starlark lint-cxx lint-rust
 
 # Run Starlark lint on Buck/Starlark/BXL files.
+[group('check')]
 lint-starlark:
     git ls-files ':(glob)**/BUCK' ':(glob)**/*.bzl' ':(glob)**/*.bxl' | xargs {{buck}} starlark lint
 
 # Build C/C++ diagnostic subtargets and print their reports.
+[group('check')]
 lint-cxx:
     {{buck}} bxl scripts/check.bxl:main -- --kind cxx --output check --target //... | xargs cat
 
 # Run Clippy for Rust targets and print its reports.
+[group('check')]
 lint-rust:
     {{buck}} bxl scripts/check.bxl:main -- --kind rust --output clippy.txt --target //... | xargs cat
 
-# Remove Buck outputs.
-clean:
-    {{buck}} clean
+# Build all Buck targets in the repository.
+[group('build')]
+build:
+    {{buck}} build //...
+
+# Build one C runtime suite.
+[group('build')]
+build-c runtime="wasmtime":
+    {{buck}} build //tests/c:{{runtime}}
+
+# Build one AssemblyScript runtime suite.
+[group('build')]
+build-asc runtime="wasmtime":
+    {{buck}} build //tests/assemblyscript/wasm32-wasip1:{{runtime}}
+
+# Build one Rust runtime suite. Use `p1` or `p3`.
+[group('build')]
+build-rust wasi="p1" runtime="wasmtime":
+    {{buck}} build //tests/rust/wasm32-wasi{{wasi}}:{{runtime}}
+
+# Build the distribution archive.
+[group('package')]
+dist:
+    {{buck}} build --show-output //tests:dist
+
+# Run the Wasmtime Buck tests.
+[group('test')]
+test:
+    {{buck}} test //tests:wasmtime
+
+# Run one C runtime suite.
+[group('test')]
+test-c runtime="wasmtime":
+    {{buck}} test //tests/c:{{runtime}}
+
+# Run one AssemblyScript runtime suite.
+[group('test')]
+test-asc runtime="wasmtime":
+    {{buck}} test //tests/assemblyscript/wasm32-wasip1:{{runtime}}
+
+# Run one Rust runtime suite. Use `p1` or `p3`.
+[group('test')]
+test-rust wasi="p1" runtime="wasmtime":
+    {{buck}} test //tests/rust/wasm32-wasi{{wasi}}:{{runtime}}
+
+# Run all Buck tests under //tests.
+[group('test')]
+test-all:
+    {{buck}} test //tests/...
+
+# Run non-Wasmtime Buck runtime suites.
+[group('test')]
+test-extra-runtimes:
+    {{buck}} test //tests:wazero //tests:wasmedge //tests:wamr
+
+# Run one Buck test target, e.g. `just test-one //tests/c:lseek_wasmtime`.
+[group('test')]
+test-one target:
+    {{buck}} test {{target}}


### PR DESCRIPTION
Some refactoring of the `justfile` in here as well, but I've updated the daily runtime validation to run similarly to the new buck2 tests. 