### PR TITLE
Pass `verbose=True` when running Buck2 tests

### DIFF
--- a/tools/run_wasi_test.py
+++ b/tools/run_wasi_test.py
@@ -57,7 +57,7 @@ def main() -> int:
 
         runtime = RuntimeAdapter(Path(args.adapter))
         exclude_filters = [Path(args.exclude_filter)] if args.exclude_filter else None
-        return run_tests([runtime], [suite_dir], exclude_filters)
+        return run_tests([runtime], [suite_dir], exclude_filters, verbose=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Helps print the stdout/stderr of the runtime at least, even if the command itself isn't reproducible just yet.