### PR TITLE
Improve error messages of failing tests

### DIFF
--- a/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.rs
@@ -21,7 +21,10 @@ unsafe fn test_fstflags_validate(dir_fd: wasi::Fd) {
         200,
         wasi::FSTFLAGS_MTIM | wasi::FSTFLAGS_MTIM_NOW,
     );
-    assert!(matches!(result, Err(wasi::ERRNO_INVAL)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(wasi::ERRNO_INVAL)),
+        "bad error: {result:?}"
+    );
 
     let result = wasi::fd_filestat_set_times(
         file_fd,
@@ -29,7 +32,10 @@ unsafe fn test_fstflags_validate(dir_fd: wasi::Fd) {
         200,
         wasi::FSTFLAGS_ATIM | wasi::FSTFLAGS_ATIM_NOW,
     );
-    assert!(matches!(result, Err(wasi::ERRNO_INVAL)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(wasi::ERRNO_INVAL)),
+        "bad error: {result:?}"
+    );
 
     wasi::fd_close(file_fd).expect("failed to close fd");
 }

--- a/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.rs
@@ -21,7 +21,7 @@ unsafe fn test_fstflags_validate(dir_fd: wasi::Fd) {
         200,
         wasi::FSTFLAGS_MTIM | wasi::FSTFLAGS_MTIM_NOW,
     );
-    assert!(matches!(result, Err(wasi::ERRNO_INVAL)));
+    assert!(matches!(result, Err(wasi::ERRNO_INVAL)), "bad error: {result:?}");
 
     let result = wasi::fd_filestat_set_times(
         file_fd,
@@ -29,7 +29,7 @@ unsafe fn test_fstflags_validate(dir_fd: wasi::Fd) {
         200,
         wasi::FSTFLAGS_ATIM | wasi::FSTFLAGS_ATIM_NOW,
     );
-    assert!(matches!(result, Err(wasi::ERRNO_INVAL)));
+    assert!(matches!(result, Err(wasi::ERRNO_INVAL)), "bad error: {result:?}");
 
     wasi::fd_close(file_fd).expect("failed to close fd");
 }

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
@@ -94,7 +94,7 @@ fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.bind(addr);
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_ephemeral_port_assignment(family: IpAddressFamily) {
@@ -134,7 +134,7 @@ fn test_non_unicast(family: IpAddressFamily) {
         let socket_addr = IpSocketAddress::new(addr, 0);
         let result = sock.bind(socket_addr);
 
-        assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+        assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
     }
 }
 
@@ -143,7 +143,7 @@ fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv6_mapped_localhost(0);
     let result = sock.bind(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_bind_addrinuse(family: IpAddressFamily) {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
@@ -94,7 +94,10 @@ fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.bind(addr);
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_ephemeral_port_assignment(family: IpAddressFamily) {
@@ -134,7 +137,10 @@ fn test_non_unicast(family: IpAddressFamily) {
         let socket_addr = IpSocketAddress::new(addr, 0);
         let result = sock.bind(socket_addr);
 
-        assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+        assert!(
+            matches!(result, Err(ErrorCode::InvalidArgument)),
+            "bad error: {result:?}"
+        );
     }
 }
 
@@ -143,7 +149,10 @@ fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv6_mapped_localhost(0);
     let result = sock.bind(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_bind_addrinuse(family: IpAddressFamily) {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-connect.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-connect.rs
@@ -18,7 +18,10 @@ async fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.connect(addr).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_non_unicast(family: IpAddressFamily) {
@@ -46,7 +49,10 @@ async fn test_non_unicast(family: IpAddressFamily) {
         let socket_addr = IpSocketAddress::new(addr, PORT);
         let result = sock.connect(socket_addr).await;
 
-        assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+        assert!(
+            matches!(result, Err(ErrorCode::InvalidArgument)),
+            "bad error: {result:?}"
+        );
     }
 }
 
@@ -55,7 +61,10 @@ async fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv4_mapped_ipv6_localhost(PORT);
     let result = sock.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_unspecified_remote_addr(family: IpAddressFamily) {
@@ -63,7 +72,10 @@ async fn test_unspecified_remote_addr(family: IpAddressFamily) {
     let addr = IpSocketAddress::unspecified(family, PORT);
     let result = sock.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_connect_0_port(family: IpAddressFamily) {
@@ -71,7 +83,10 @@ async fn test_connect_0_port(family: IpAddressFamily) {
     let addr = IpSocketAddress::localhost(family, 0);
     let result = sock.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_connected_state(family: IpAddressFamily) {
@@ -87,7 +102,10 @@ async fn test_connected_state(family: IpAddressFamily) {
     assert!(result.is_ok());
 
     let result = sock.connect(server_addr).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_listening_state(family: IpAddressFamily) {
@@ -100,7 +118,10 @@ async fn test_listening_state(family: IpAddressFamily) {
     let result = listener
         .connect(IpSocketAddress::localhost(family, PORT))
         .await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_connection_refused(family: IpAddressFamily) {
@@ -112,7 +133,10 @@ async fn test_connection_refused(family: IpAddressFamily) {
     let sock2 = TcpSocket::create(family).unwrap();
     let result = sock2.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::ConnectionRefused)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::ConnectionRefused)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_explicit_bind(family: IpAddressFamily) {
@@ -151,7 +175,10 @@ async fn test_explicit_bind_addrinuse(family: IpAddressFamily) {
     let client = TcpSocket::create(family).unwrap();
 
     let result = client.bind(listener_address);
-    assert!(matches!(result, Err(ErrorCode::AddressInUse)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::AddressInUse)),
+        "bad error: {result:?}"
+    );
 }
 
 impl Guest for Component {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-connect.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-connect.rs
@@ -18,7 +18,7 @@ async fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.connect(addr).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 async fn test_non_unicast(family: IpAddressFamily) {
@@ -46,7 +46,7 @@ async fn test_non_unicast(family: IpAddressFamily) {
         let socket_addr = IpSocketAddress::new(addr, PORT);
         let result = sock.connect(socket_addr).await;
 
-        assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+        assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
     }
 }
 
@@ -55,7 +55,7 @@ async fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv4_mapped_ipv6_localhost(PORT);
     let result = sock.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 async fn test_unspecified_remote_addr(family: IpAddressFamily) {
@@ -63,7 +63,7 @@ async fn test_unspecified_remote_addr(family: IpAddressFamily) {
     let addr = IpSocketAddress::unspecified(family, PORT);
     let result = sock.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 async fn test_connect_0_port(family: IpAddressFamily) {
@@ -71,7 +71,7 @@ async fn test_connect_0_port(family: IpAddressFamily) {
     let addr = IpSocketAddress::localhost(family, 0);
     let result = sock.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 async fn test_connected_state(family: IpAddressFamily) {
@@ -87,7 +87,7 @@ async fn test_connected_state(family: IpAddressFamily) {
     assert!(result.is_ok());
 
     let result = sock.connect(server_addr).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)));
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 }
 
 async fn test_listening_state(family: IpAddressFamily) {
@@ -100,7 +100,7 @@ async fn test_listening_state(family: IpAddressFamily) {
     let result = listener
         .connect(IpSocketAddress::localhost(family, PORT))
         .await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)));
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 }
 
 async fn test_connection_refused(family: IpAddressFamily) {
@@ -112,7 +112,7 @@ async fn test_connection_refused(family: IpAddressFamily) {
     let sock2 = TcpSocket::create(family).unwrap();
     let result = sock2.connect(addr).await;
 
-    assert!(matches!(result, Err(ErrorCode::ConnectionRefused)));
+    assert!(matches!(result, Err(ErrorCode::ConnectionRefused)), "bad error: {result:?}");
 }
 
 async fn test_explicit_bind(family: IpAddressFamily) {
@@ -151,7 +151,7 @@ async fn test_explicit_bind_addrinuse(family: IpAddressFamily) {
     let client = TcpSocket::create(family).unwrap();
 
     let result = client.bind(listener_address);
-    assert!(matches!(result, Err(ErrorCode::AddressInUse)));
+    assert!(matches!(result, Err(ErrorCode::AddressInUse)), "bad error: {result:?}");
 }
 
 impl Guest for Component {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-listen.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-listen.rs
@@ -59,7 +59,7 @@ fn test_listening(fam: IpAddressFamily) {
     sock.bind(addr).unwrap();
     sock.listen().unwrap();
     let result = sock.listen();
-    assert!(matches!(result, Err(ErrorCode::InvalidState)));
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 }
 
 impl Guest for Component {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-listen.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-listen.rs
@@ -59,7 +59,10 @@ fn test_listening(fam: IpAddressFamily) {
     sock.bind(addr).unwrap();
     sock.listen().unwrap();
     let result = sock.listen();
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 }
 
 impl Guest for Component {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-properties.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-properties.rs
@@ -14,56 +14,56 @@ fn test_properties(family: IpAddressFamily) {
         sock.set_listen_backlog_size(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_listen_backlog_size(1), Ok(_)));
-    assert!(matches!(sock.set_listen_backlog_size(u64::MAX), Ok(_)));
+    sock.set_listen_backlog_size(1).unwrap();
+    sock.set_listen_backlog_size(u64::MAX).unwrap();
 
-    assert!(matches!(sock.set_keep_alive_enabled(true), Ok(_)));
-    assert!(matches!(sock.set_keep_alive_enabled(false), Ok(_)));
+    sock.set_keep_alive_enabled(true).unwrap();
+    sock.set_keep_alive_enabled(false).unwrap();
 
     assert!(matches!(
         sock.set_keep_alive_idle_time(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_keep_alive_idle_time(1), Ok(_)));
+    sock.set_keep_alive_idle_time(1).unwrap();
     let idle_time = sock.get_keep_alive_idle_time().unwrap();
     assert!(idle_time > 0 && idle_time <= 1 * SECOND);
-    assert!(matches!(sock.set_keep_alive_idle_time(u64::MAX), Ok(_)));
+    sock.set_keep_alive_idle_time(u64::MAX).unwrap();
 
     assert!(matches!(
         sock.set_keep_alive_interval(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_keep_alive_interval(1), Ok(_)));
+    sock.set_keep_alive_interval(1).unwrap();
     let idle_time = sock.get_keep_alive_interval().unwrap();
     assert!(idle_time > 0 && idle_time <= 1 * SECOND);
-    assert!(matches!(sock.set_keep_alive_interval(u64::MAX), Ok(_)));
+    sock.set_keep_alive_interval(u64::MAX).unwrap();
 
     assert!(matches!(
         sock.set_keep_alive_count(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_keep_alive_count(1), Ok(_)));
-    assert!(matches!(sock.set_keep_alive_count(u32::MAX), Ok(_)));
+    sock.set_keep_alive_count(1).unwrap();
+    sock.set_keep_alive_count(u32::MAX).unwrap();
 
     assert!(matches!(
         sock.set_hop_limit(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_hop_limit(1), Ok(_)));
-    assert!(matches!(sock.set_hop_limit(u8::MAX), Ok(_)));
+    sock.set_hop_limit(1).unwrap();
+    sock.set_hop_limit(u8::MAX).unwrap();
 
     assert!(matches!(
         sock.set_receive_buffer_size(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_receive_buffer_size(1), Ok(_)));
-    assert!(matches!(sock.set_receive_buffer_size(u64::MAX), Ok(_)));
+    sock.set_receive_buffer_size(1).unwrap();
+    sock.set_receive_buffer_size(u64::MAX).unwrap();
     assert!(matches!(
         sock.set_send_buffer_size(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_send_buffer_size(1), Ok(_)));
-    assert!(matches!(sock.set_send_buffer_size(u64::MAX), Ok(_)));
+    sock.set_send_buffer_size(1).unwrap();
+    sock.set_send_buffer_size(u64::MAX).unwrap();
 
     sock.set_keep_alive_enabled(true).unwrap();
     assert_eq!(sock.get_keep_alive_enabled().unwrap(), true);

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-receive.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-receive.rs
@@ -12,7 +12,8 @@ async fn test_connected_state(family: IpAddressFamily) {
     let sock = TcpSocket::create(family).unwrap();
 
     let (_, fut) = sock.receive();
-    assert!(matches!(fut.await, Err(ErrorCode::InvalidState)));
+    let result = fut.await;
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 }
 
 async fn test_multiple_receive(family: IpAddressFamily) {
@@ -29,7 +30,8 @@ async fn test_multiple_receive(family: IpAddressFamily) {
             let (_, fut1) = sock.receive();
             let (_, fut2) = sock.receive();
             assert!(fut1.await.is_ok());
-            assert!(matches!(fut2.await, Err(ErrorCode::InvalidState)));
+            let result = fut2.await;
+            assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
         },
         async {
             let local_addr = server.get_local_address().unwrap();

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-receive.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-receive.rs
@@ -13,7 +13,10 @@ async fn test_connected_state(family: IpAddressFamily) {
 
     let (_, fut) = sock.receive();
     let result = fut.await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_multiple_receive(family: IpAddressFamily) {
@@ -31,7 +34,10 @@ async fn test_multiple_receive(family: IpAddressFamily) {
             let (_, fut2) = sock.receive();
             assert!(fut1.await.is_ok());
             let result = fut2.await;
-            assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+            assert!(
+                matches!(result, Err(ErrorCode::InvalidState)),
+                "bad error: {result:?}"
+            );
         },
         async {
             let local_addr = server.get_local_address().unwrap();

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-send.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-send.rs
@@ -13,7 +13,10 @@ async fn test_connected_state(family: IpAddressFamily) {
     let (_, send_rx) = sockets::wit_stream::new();
 
     let result = sock.send(send_rx).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 }
 
 // Dropping the write half shouldn't cause the write to be lost.

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-send.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-send.rs
@@ -13,7 +13,7 @@ async fn test_connected_state(family: IpAddressFamily) {
     let (_, send_rx) = sockets::wit_stream::new();
 
     let result = sock.send(send_rx).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)));
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 }
 
 // Dropping the write half shouldn't cause the write to be lost.

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-bind.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-bind.rs
@@ -16,7 +16,10 @@ fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.bind(addr);
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_already_bound(family: IpAddressFamily) {
@@ -24,7 +27,10 @@ fn test_already_bound(family: IpAddressFamily) {
     let addr = IpSocketAddress::localhost(family, 0);
     assert!(sock.bind(addr).is_ok());
     let result = sock.bind(addr);
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_not_bindable(family: IpAddressFamily) {
@@ -68,7 +74,10 @@ fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv4_mapped_ipv6_localhost(0);
     let result = sock.bind(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_unspecified_addr(family: IpAddressFamily) {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-bind.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-bind.rs
@@ -16,14 +16,15 @@ fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.bind(addr);
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_already_bound(family: IpAddressFamily) {
     let sock = UdpSocket::create(family).unwrap();
     let addr = IpSocketAddress::localhost(family, 0);
     assert!(sock.bind(addr).is_ok());
-    assert!(matches!(sock.bind(addr), Err(ErrorCode::InvalidState)));
+    let result = sock.bind(addr);
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 }
 
 fn test_not_bindable(family: IpAddressFamily) {
@@ -67,7 +68,7 @@ fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv4_mapped_ipv6_localhost(0);
     let result = sock.bind(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_unspecified_addr(family: IpAddressFamily) {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-connect.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-connect.rs
@@ -18,7 +18,7 @@ fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.connect(addr);
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_reject_dual_stack() {
@@ -26,7 +26,7 @@ fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv4_mapped_ipv6_localhost(PORT);
     let result = sock.connect(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_unspecified_remote_addr(family: IpAddressFamily) {
@@ -34,7 +34,7 @@ fn test_unspecified_remote_addr(family: IpAddressFamily) {
     let addr = IpSocketAddress::unspecified(family, PORT);
     let result = sock.connect(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_connect_0_port(family: IpAddressFamily) {
@@ -42,7 +42,7 @@ fn test_connect_0_port(family: IpAddressFamily) {
     let addr = IpSocketAddress::localhost(family, 0);
     let result = sock.connect(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 fn test_implicit_bind(family: IpAddressFamily) {
@@ -73,7 +73,7 @@ fn test_explicit_bind_addrinuse(family: IpAddressFamily) {
     let sock2 = UdpSocket::create(family).unwrap();
     let result = sock2.bind(sock1_addr);
 
-    assert!(matches!(result, Err(ErrorCode::AddressInUse)));
+    assert!(matches!(result, Err(ErrorCode::AddressInUse)), "bad error: {result:?}");
 }
 
 fn test_reconnect_same_address(family: IpAddressFamily) {
@@ -93,7 +93,8 @@ fn test_reconnect_same_address(family: IpAddressFamily) {
 
 fn test_reconnect_different_address(family: IpAddressFamily) {
     let sock = UdpSocket::create(family).unwrap();
-    assert!(matches!(sock.disconnect(), Err(ErrorCode::InvalidState)));
+    let result = sock.disconnect();
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 
     let addr1 = IpSocketAddress::localhost(family, PORT);
     sock.connect(addr1).unwrap();

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-connect.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-connect.rs
@@ -18,7 +18,10 @@ fn test_invalid_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.connect(addr);
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_reject_dual_stack() {
@@ -26,7 +29,10 @@ fn test_reject_dual_stack() {
     let addr = IpSocketAddress::ipv4_mapped_ipv6_localhost(PORT);
     let result = sock.connect(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_unspecified_remote_addr(family: IpAddressFamily) {
@@ -34,7 +40,10 @@ fn test_unspecified_remote_addr(family: IpAddressFamily) {
     let addr = IpSocketAddress::unspecified(family, PORT);
     let result = sock.connect(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_connect_0_port(family: IpAddressFamily) {
@@ -42,7 +51,10 @@ fn test_connect_0_port(family: IpAddressFamily) {
     let addr = IpSocketAddress::localhost(family, 0);
     let result = sock.connect(addr);
 
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_implicit_bind(family: IpAddressFamily) {
@@ -73,7 +85,10 @@ fn test_explicit_bind_addrinuse(family: IpAddressFamily) {
     let sock2 = UdpSocket::create(family).unwrap();
     let result = sock2.bind(sock1_addr);
 
-    assert!(matches!(result, Err(ErrorCode::AddressInUse)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::AddressInUse)),
+        "bad error: {result:?}"
+    );
 }
 
 fn test_reconnect_same_address(family: IpAddressFamily) {
@@ -94,7 +109,10 @@ fn test_reconnect_same_address(family: IpAddressFamily) {
 fn test_reconnect_different_address(family: IpAddressFamily) {
     let sock = UdpSocket::create(family).unwrap();
     let result = sock.disconnect();
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 
     let addr1 = IpSocketAddress::localhost(family, PORT);
     sock.connect(addr1).unwrap();

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-properties.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-properties.rs
@@ -11,21 +11,21 @@ fn test_properties(family: IpAddressFamily) {
         sock.set_unicast_hop_limit(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_unicast_hop_limit(1), Ok(_)));
-    assert!(matches!(sock.set_unicast_hop_limit(u8::MAX), Ok(_)));
+    sock.set_unicast_hop_limit(1).unwrap();
+    sock.set_unicast_hop_limit(u8::MAX).unwrap();
 
     assert!(matches!(
         sock.set_receive_buffer_size(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_receive_buffer_size(1), Ok(_)));
-    assert!(matches!(sock.set_receive_buffer_size(u64::MAX), Ok(_)));
+    sock.set_receive_buffer_size(1).unwrap();
+    sock.set_receive_buffer_size(u64::MAX).unwrap();
     assert!(matches!(
         sock.set_send_buffer_size(0),
         Err(ErrorCode::InvalidArgument)
     ));
-    assert!(matches!(sock.set_send_buffer_size(1), Ok(_)));
-    assert!(matches!(sock.set_send_buffer_size(u64::MAX), Ok(_)));
+    sock.set_send_buffer_size(1).unwrap();
+    sock.set_send_buffer_size(u64::MAX).unwrap();
 
     sock.set_unicast_hop_limit(42).unwrap();
     assert_eq!(sock.get_unicast_hop_limit().unwrap(), 42);

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-receive.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-receive.rs
@@ -10,7 +10,10 @@ export!(Component);
 async fn test_not_bound(family: IpAddressFamily) {
     let sock = UdpSocket::create(family).unwrap();
     let result = sock.receive().await;
-    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidState)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_receive_data(family: IpAddressFamily) {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-receive.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-receive.rs
@@ -9,7 +9,8 @@ export!(Component);
 
 async fn test_not_bound(family: IpAddressFamily) {
     let sock = UdpSocket::create(family).unwrap();
-    assert!(matches!(sock.receive().await, Err(ErrorCode::InvalidState)));
+    let result = sock.receive().await;
+    assert!(matches!(result, Err(ErrorCode::InvalidState)), "bad error: {result:?}");
 }
 
 async fn test_receive_data(family: IpAddressFamily) {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-send.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-send.rs
@@ -18,7 +18,7 @@ async fn test_wrong_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.send(vec![0; 1], Some(addr)).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 async fn test_implicit_bind(family: IpAddressFamily) {
@@ -70,14 +70,14 @@ async fn test_unspecified_remote_addr(family: IpAddressFamily) {
     // FIXME: According to the spec this should return
     //     `invalid-argument`: The IP address in `remote-address` is
     //     set to INADDR_ANY (`0.0.0.0` / `::`).
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
 }
 
 async fn test_remote_addr_with_port_0(family: IpAddressFamily) {
     let sock = UdpSocket::create(family).unwrap();
     let addr = IpSocketAddress::localhost(family, 0);
     let result = sock.send(vec![0; 1], Some(addr)).await;
-    assert!(matches!(result, Err(ErrorCode::AddressNotBindable)));
+    assert!(matches!(result, Err(ErrorCode::AddressNotBindable)), "bad error: {result:?}");
 }
 
 async fn test_datagram_too_large(family: IpAddressFamily) {
@@ -85,7 +85,7 @@ async fn test_datagram_too_large(family: IpAddressFamily) {
     let addr = IpSocketAddress::localhost(family, PORT);
     let result = sock.send(vec![0u8; 65536], Some(addr)).await;
 
-    assert!(matches!(result, Err(ErrorCode::DatagramTooLarge)));
+    assert!(matches!(result, Err(ErrorCode::DatagramTooLarge)), "bad error: {result:?}");
 }
 
 impl Guest for Component {

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-send.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-send.rs
@@ -18,7 +18,10 @@ async fn test_wrong_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.send(vec![0; 1], Some(addr)).await;
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_implicit_bind(family: IpAddressFamily) {
@@ -70,14 +73,20 @@ async fn test_unspecified_remote_addr(family: IpAddressFamily) {
     // FIXME: According to the spec this should return
     //     `invalid-argument`: The IP address in `remote-address` is
     //     set to INADDR_ANY (`0.0.0.0` / `::`).
-    assert!(matches!(result, Err(ErrorCode::InvalidArgument)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::InvalidArgument)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_remote_addr_with_port_0(family: IpAddressFamily) {
     let sock = UdpSocket::create(family).unwrap();
     let addr = IpSocketAddress::localhost(family, 0);
     let result = sock.send(vec![0; 1], Some(addr)).await;
-    assert!(matches!(result, Err(ErrorCode::AddressNotBindable)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::AddressNotBindable)),
+        "bad error: {result:?}"
+    );
 }
 
 async fn test_datagram_too_large(family: IpAddressFamily) {
@@ -85,7 +94,10 @@ async fn test_datagram_too_large(family: IpAddressFamily) {
     let addr = IpSocketAddress::localhost(family, PORT);
     let result = sock.send(vec![0u8; 65536], Some(addr)).await;
 
-    assert!(matches!(result, Err(ErrorCode::DatagramTooLarge)), "bad error: {result:?}");
+    assert!(
+        matches!(result, Err(ErrorCode::DatagramTooLarge)),
+        "bad error: {result:?}"
+    );
 }
 
 impl Guest for Component {


### PR DESCRIPTION
Use `.unwrap()` where applicable, and otherwise add extra error context in `assert!` error messages for when they fail.