### PR TITLE
Make the `sockets-tcp-connect` test have a deterministic errror

### DIFF
--- a/expectations/wasmtime-linux.json
+++ b/expectations/wasmtime-linux.json
@@ -3,7 +3,6 @@
     "remove_directory_trailing_slashes": "Wasmtime returns ERRNO_INVAL for path_remove_directory with a trailing slash"
   },
   "WASI Rust tests [wasm32-wasip3]": {
-    "sockets-tcp-connect": "requires a TCP peer managed outside the component under test",
     "sockets-udp-send": "requires a UDP peer managed outside the component under test"
   }
 }

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-connect.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-connect.rs
@@ -144,6 +144,7 @@ async fn test_explicit_bind_addrinuse(family: IpAddressFamily) {
         let bind_address = IpSocketAddress::localhost(family, 0);
         let listener = TcpSocket::create(family).unwrap();
         listener.bind(bind_address).unwrap();
+        listener.listen().unwrap();
         listener
     };
 


### PR DESCRIPTION
Takes the recommendation of bytecodealliance/wasmtime#13396 to update the test to make the test report a deterministic error.

cc @badeend as well, this is a belated follow-up frmo your comment at https://github.com/bytecodealliance/wasmtime/issues/13396#issuecomment-4525057000