### PR TITLE
Adjust expected errors in `sockets-udp-send`

### DIFF
--- a/tests/rust/wasm32-wasip3/src/bin/sockets-udp-send.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-udp-send.rs
@@ -19,7 +19,12 @@ async fn test_wrong_address_family(family: IpAddressFamily) {
 
     let result = sock.send(vec![0; 1], Some(addr)).await;
     assert!(
-        matches!(result, Err(ErrorCode::InvalidArgument)),
+        matches!(
+            result,
+            Err(ErrorCode::InvalidArgument
+                | ErrorCode::NotSupported
+                | ErrorCode::RemoteUnreachable)
+        ),
         "bad error: {result:?}"
     );
 }


### PR DESCRIPTION
Adds in error codes that pop out on Linux once `IPV6_V6ONLY` is enabled.