### PR TITLE
fix: publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,4 +135,5 @@ jobs:
           git add -f tests/c/testsuite
           git add -f tests/rust/testsuite
           git diff --quiet HEAD || git commit -m "Update prebuilt test binaries after commit ${{ github.sha }}"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer $GITHUB_TOKEN" push origin HEAD:prod/testsuite-base
+          auth="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" push origin HEAD:prod/testsuite-base


### PR DESCRIPTION
This dance with basic auth on push is attempt to satisfy zizmor checks so it works without checkout persisting credentials.