### PR TITLE
fix: avoid following symlinks when cleaning up test output

### DIFF
--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -351,7 +351,10 @@ def join_http_url(http_server: str, path: str) -> str:
 
 def _cleanup_test_output(host_dir: Path) -> None:
     for f in host_dir.glob("**/*.cleanup"):
-        if f.is_symlink() or f.is_file():
+        if f.is_symlink():
+            continue
+
+        if f.is_file():
             f.unlink()
         elif f.is_dir():
             shutil.rmtree(f)


### PR DESCRIPTION
Resolves #81 