### PR TITLE
chore: update Jco to v1.22.0

### DIFF
--- a/expectations/jco/linux.toml
+++ b/expectations/jco/linux.toml
@@ -2,8 +2,3 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
-
-# jco currently times out on this test
-[[suite.test]]
-name = "sockets-udp-receive"
-action = "skip"

--- a/expectations/jco/macos.toml
+++ b/expectations/jco/macos.toml
@@ -2,8 +2,3 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
-
-# jco currently times out on this test
-[[suite.test]]
-name = "sockets-udp-receive"
-action = "skip"

--- a/expectations/jco/windows.toml
+++ b/expectations/jco/windows.toml
@@ -2,8 +2,3 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
-
-# jco currently times out on this test
-[[suite.test]]
-name = "sockets-udp-receive"
-action = "skip"

--- a/third-party/js/package-lock.json
+++ b/third-party/js/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@bytecodealliance/jco": "1.21.0"
+        "@bytecodealliance/jco": "1.22.0"
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {
@@ -45,15 +45,15 @@
       }
     },
     "node_modules/@bytecodealliance/jco": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.21.0.tgz",
-      "integrity": "sha512-XFW7ZAmoTfUa/OTGFnHWbTv63pO80n4cU/56sQUIHvkPlEnW7epDvnzBYzG4gCBekiUPWnHd30S1XNdl4n1Ccg==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.22.0.tgz",
+      "integrity": "sha512-gepzD1/XF4l/copHKuYOkm120PQdFzRgSnFRnvhlNkWFynDT2H0Q3zNa+4g9EszQvUM8i+7us5Ga698ABdnPAg==",
       "license": "(Apache-2.0 WITH LLVM-exception)",
       "dependencies": {
         "@bytecodealliance/componentize-js": "^0.21.0",
         "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
         "@bytecodealliance/preview2-shim": "^0.17.9",
-        "@bytecodealliance/preview3-shim": "^0.1.0",
+        "@bytecodealliance/preview3-shim": "^0.1.2",
         "binaryen": "^123.0.0",
         "commander": "^14",
         "mkdirp": "^3",
@@ -421,9 +421,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -439,9 +436,6 @@
       "integrity": "sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -459,9 +453,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -477,9 +468,6 @@
       "integrity": "sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -497,9 +485,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -516,9 +501,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -534,9 +516,6 @@
       "integrity": "sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -732,9 +711,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +726,6 @@
       "integrity": "sha512-wi9zQPMDHrBuRuT7Iurfidc9qlZh7cKa5vfYzOWNBCaqJdgxmNOFzvYen02wVUxSWGKhpiPHxrPX0jdRyJ8Npg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -770,9 +743,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -788,9 +758,6 @@
       "integrity": "sha512-y36Hh1a5TA+oIGtlc8lT7N9vdHXBlhBetQJW0p457KbiVQ7jF7AZkaPWhESkjHWAsTVKD2OjCa9ZqfaqhSI0FQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -808,9 +775,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,9 +790,6 @@
       "integrity": "sha512-AxFt0reY6Q2rfudABmMTFGR8tFFr58NlH2rRBQgcj+F+iEwgJ+jMwAPhXd2y1I2zaI8GspuahedUYQinqxWqjA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/third-party/js/package.json
+++ b/third-party/js/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@bytecodealliance/jco": "1.21.0"
+    "@bytecodealliance/jco": "1.22.0"
   }
 }

--- a/toolchains/runtimes/runtimes.bzl
+++ b/toolchains/runtimes/runtimes.bzl
@@ -4,7 +4,7 @@ load("@wasmono//toolchains/wasm:node.bzl", "NodeInfo")
 load("@wasmono//:defs.bzl", "host_arch", "host_os")
 load(":releases.bzl", "WAMR_RELEASES", "WASMEDGE_RELEASES", "WASMTIME_RELEASES", "WAZERO_RELEASES")
 
-DEFAULT_JCO_VERSION = "1.21.0"
+DEFAULT_JCO_VERSION = "1.22.0"
 DEFAULT_NODE_VERSION = "24.16.0"
 DEFAULT_WAMR_VERSION = "2.4.4"
 DEFAULT_WASMEDGE_VERSION = "0.17.0"


### PR DESCRIPTION
Now that [jco v1.22.0](https://www.npmjs.com/package/@bytecodealliance/jco/v/1.22.0) is released, we should update and we should see the stuck windows UDP tests pass. 