### PR TITLE
wasi 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /tests/assemblyscript/testsuite/
 __pycache__
 buck-out/
+target/
 
 *~
 \#*\#

--- a/expectations/jco/linux.toml
+++ b/expectations/jco/linux.toml
@@ -2,3 +2,129 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
+
+# TODO(wasi-0.3.0): temporary skip during the WASI 0.3.0 chicken/egg period.
+# The wasip3 suite was bumped to the WASI 0.3.0 release, but no published
+# jco release supports 0.3.0 yet (only the rc). Re-enable by deleting the
+# skips below once a jco release ships WASI 0.3.0 support.
+
+[[suite.test]]
+name = "cli-env"
+action = "skip"
+[[suite.test]]
+name = "cli-exit"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio-roundtrip"
+action = "skip"
+[[suite.test]]
+name = "cli-terminal"
+action = "skip"
+[[suite.test]]
+name = "filesystem-advise"
+action = "skip"
+[[suite.test]]
+name = "filesystem-dotdot"
+action = "skip"
+[[suite.test]]
+name = "filesystem-flags-and-type"
+action = "skip"
+[[suite.test]]
+name = "filesystem-hard-links"
+action = "skip"
+[[suite.test]]
+name = "filesystem-io"
+action = "skip"
+[[suite.test]]
+name = "filesystem-is-same-object"
+action = "skip"
+[[suite.test]]
+name = "filesystem-metadata-hash"
+action = "skip"
+[[suite.test]]
+name = "filesystem-mkdir-rmdir"
+action = "skip"
+[[suite.test]]
+name = "filesystem-open-errors"
+action = "skip"
+[[suite.test]]
+name = "filesystem-read-directory"
+action = "skip"
+[[suite.test]]
+name = "filesystem-rename"
+action = "skip"
+[[suite.test]]
+name = "filesystem-set-size"
+action = "skip"
+[[suite.test]]
+name = "filesystem-stat"
+action = "skip"
+[[suite.test]]
+name = "filesystem-unlink-errors"
+action = "skip"
+[[suite.test]]
+name = "http-fields"
+action = "skip"
+[[suite.test]]
+name = "http-request"
+action = "skip"
+[[suite.test]]
+name = "http-response"
+action = "skip"
+[[suite.test]]
+name = "http-service"
+action = "skip"
+[[suite.test]]
+name = "monotonic-clock"
+action = "skip"
+[[suite.test]]
+name = "multi-clock-wait"
+action = "skip"
+[[suite.test]]
+name = "random"
+action = "skip"
+[[suite.test]]
+name = "run-with-err"
+action = "skip"
+[[suite.test]]
+name = "sockets-echo"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-listen"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-send"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-send"
+action = "skip"
+[[suite.test]]
+name = "wall-clock"
+action = "skip"

--- a/expectations/jco/macos.toml
+++ b/expectations/jco/macos.toml
@@ -2,3 +2,129 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
+
+# TODO(wasi-0.3.0): temporary skip during the WASI 0.3.0 chicken/egg period.
+# The wasip3 suite was bumped to the WASI 0.3.0 release, but no published
+# jco release supports 0.3.0 yet (only the rc). Re-enable by deleting the
+# skips below once a jco release ships WASI 0.3.0 support.
+
+[[suite.test]]
+name = "cli-env"
+action = "skip"
+[[suite.test]]
+name = "cli-exit"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio-roundtrip"
+action = "skip"
+[[suite.test]]
+name = "cli-terminal"
+action = "skip"
+[[suite.test]]
+name = "filesystem-advise"
+action = "skip"
+[[suite.test]]
+name = "filesystem-dotdot"
+action = "skip"
+[[suite.test]]
+name = "filesystem-flags-and-type"
+action = "skip"
+[[suite.test]]
+name = "filesystem-hard-links"
+action = "skip"
+[[suite.test]]
+name = "filesystem-io"
+action = "skip"
+[[suite.test]]
+name = "filesystem-is-same-object"
+action = "skip"
+[[suite.test]]
+name = "filesystem-metadata-hash"
+action = "skip"
+[[suite.test]]
+name = "filesystem-mkdir-rmdir"
+action = "skip"
+[[suite.test]]
+name = "filesystem-open-errors"
+action = "skip"
+[[suite.test]]
+name = "filesystem-read-directory"
+action = "skip"
+[[suite.test]]
+name = "filesystem-rename"
+action = "skip"
+[[suite.test]]
+name = "filesystem-set-size"
+action = "skip"
+[[suite.test]]
+name = "filesystem-stat"
+action = "skip"
+[[suite.test]]
+name = "filesystem-unlink-errors"
+action = "skip"
+[[suite.test]]
+name = "http-fields"
+action = "skip"
+[[suite.test]]
+name = "http-request"
+action = "skip"
+[[suite.test]]
+name = "http-response"
+action = "skip"
+[[suite.test]]
+name = "http-service"
+action = "skip"
+[[suite.test]]
+name = "monotonic-clock"
+action = "skip"
+[[suite.test]]
+name = "multi-clock-wait"
+action = "skip"
+[[suite.test]]
+name = "random"
+action = "skip"
+[[suite.test]]
+name = "run-with-err"
+action = "skip"
+[[suite.test]]
+name = "sockets-echo"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-listen"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-send"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-send"
+action = "skip"
+[[suite.test]]
+name = "wall-clock"
+action = "skip"

--- a/expectations/jco/windows.toml
+++ b/expectations/jco/windows.toml
@@ -2,3 +2,129 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
+
+# TODO(wasi-0.3.0): temporary skip during the WASI 0.3.0 chicken/egg period.
+# The wasip3 suite was bumped to the WASI 0.3.0 release, but no published
+# jco release supports 0.3.0 yet (only the rc). Re-enable by deleting the
+# skips below once a jco release ships WASI 0.3.0 support.
+
+[[suite.test]]
+name = "cli-env"
+action = "skip"
+[[suite.test]]
+name = "cli-exit"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio-roundtrip"
+action = "skip"
+[[suite.test]]
+name = "cli-terminal"
+action = "skip"
+[[suite.test]]
+name = "filesystem-advise"
+action = "skip"
+[[suite.test]]
+name = "filesystem-dotdot"
+action = "skip"
+[[suite.test]]
+name = "filesystem-flags-and-type"
+action = "skip"
+[[suite.test]]
+name = "filesystem-hard-links"
+action = "skip"
+[[suite.test]]
+name = "filesystem-io"
+action = "skip"
+[[suite.test]]
+name = "filesystem-is-same-object"
+action = "skip"
+[[suite.test]]
+name = "filesystem-metadata-hash"
+action = "skip"
+[[suite.test]]
+name = "filesystem-mkdir-rmdir"
+action = "skip"
+[[suite.test]]
+name = "filesystem-open-errors"
+action = "skip"
+[[suite.test]]
+name = "filesystem-read-directory"
+action = "skip"
+[[suite.test]]
+name = "filesystem-rename"
+action = "skip"
+[[suite.test]]
+name = "filesystem-set-size"
+action = "skip"
+[[suite.test]]
+name = "filesystem-stat"
+action = "skip"
+[[suite.test]]
+name = "filesystem-unlink-errors"
+action = "skip"
+[[suite.test]]
+name = "http-fields"
+action = "skip"
+[[suite.test]]
+name = "http-request"
+action = "skip"
+[[suite.test]]
+name = "http-response"
+action = "skip"
+[[suite.test]]
+name = "http-service"
+action = "skip"
+[[suite.test]]
+name = "monotonic-clock"
+action = "skip"
+[[suite.test]]
+name = "multi-clock-wait"
+action = "skip"
+[[suite.test]]
+name = "random"
+action = "skip"
+[[suite.test]]
+name = "run-with-err"
+action = "skip"
+[[suite.test]]
+name = "sockets-echo"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-listen"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-send"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-send"
+action = "skip"
+[[suite.test]]
+name = "wall-clock"
+action = "skip"

--- a/expectations/wasmtime/linux.toml
+++ b/expectations/wasmtime/linux.toml
@@ -1,1 +1,130 @@
 version = 1
+
+[[suite]]
+name = "WASI Rust tests [wasm32-wasip3]"
+
+# TODO(wasi-0.3.0): temporary skip during the WASI 0.3.0 chicken/egg period.
+# The wasip3 suite was bumped to the WASI 0.3.0 release, but no published
+# wasmtime release supports 0.3.0 yet (only the rc). Re-enable by deleting the
+# skips below once a wasmtime release ships WASI 0.3.0 support.
+
+[[suite.test]]
+name = "cli-env"
+action = "skip"
+[[suite.test]]
+name = "cli-exit"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio-roundtrip"
+action = "skip"
+[[suite.test]]
+name = "cli-terminal"
+action = "skip"
+[[suite.test]]
+name = "filesystem-advise"
+action = "skip"
+[[suite.test]]
+name = "filesystem-dotdot"
+action = "skip"
+[[suite.test]]
+name = "filesystem-flags-and-type"
+action = "skip"
+[[suite.test]]
+name = "filesystem-hard-links"
+action = "skip"
+[[suite.test]]
+name = "filesystem-io"
+action = "skip"
+[[suite.test]]
+name = "filesystem-is-same-object"
+action = "skip"
+[[suite.test]]
+name = "filesystem-metadata-hash"
+action = "skip"
+[[suite.test]]
+name = "filesystem-mkdir-rmdir"
+action = "skip"
+[[suite.test]]
+name = "filesystem-open-errors"
+action = "skip"
+[[suite.test]]
+name = "filesystem-read-directory"
+action = "skip"
+[[suite.test]]
+name = "filesystem-rename"
+action = "skip"
+[[suite.test]]
+name = "filesystem-set-size"
+action = "skip"
+[[suite.test]]
+name = "filesystem-stat"
+action = "skip"
+[[suite.test]]
+name = "filesystem-unlink-errors"
+action = "skip"
+[[suite.test]]
+name = "http-fields"
+action = "skip"
+[[suite.test]]
+name = "http-request"
+action = "skip"
+[[suite.test]]
+name = "http-response"
+action = "skip"
+[[suite.test]]
+name = "http-service"
+action = "skip"
+[[suite.test]]
+name = "monotonic-clock"
+action = "skip"
+[[suite.test]]
+name = "multi-clock-wait"
+action = "skip"
+[[suite.test]]
+name = "random"
+action = "skip"
+[[suite.test]]
+name = "run-with-err"
+action = "skip"
+[[suite.test]]
+name = "sockets-echo"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-listen"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-send"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-send"
+action = "skip"
+[[suite.test]]
+name = "wall-clock"
+action = "skip"

--- a/expectations/wasmtime/macos.toml
+++ b/expectations/wasmtime/macos.toml
@@ -1,1 +1,130 @@
 version = 1
+
+[[suite]]
+name = "WASI Rust tests [wasm32-wasip3]"
+
+# TODO(wasi-0.3.0): temporary skip during the WASI 0.3.0 chicken/egg period.
+# The wasip3 suite was bumped to the WASI 0.3.0 release, but no published
+# wasmtime release supports 0.3.0 yet (only the rc). Re-enable by deleting the
+# skips below once a wasmtime release ships WASI 0.3.0 support.
+
+[[suite.test]]
+name = "cli-env"
+action = "skip"
+[[suite.test]]
+name = "cli-exit"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio-roundtrip"
+action = "skip"
+[[suite.test]]
+name = "cli-terminal"
+action = "skip"
+[[suite.test]]
+name = "filesystem-advise"
+action = "skip"
+[[suite.test]]
+name = "filesystem-dotdot"
+action = "skip"
+[[suite.test]]
+name = "filesystem-flags-and-type"
+action = "skip"
+[[suite.test]]
+name = "filesystem-hard-links"
+action = "skip"
+[[suite.test]]
+name = "filesystem-io"
+action = "skip"
+[[suite.test]]
+name = "filesystem-is-same-object"
+action = "skip"
+[[suite.test]]
+name = "filesystem-metadata-hash"
+action = "skip"
+[[suite.test]]
+name = "filesystem-mkdir-rmdir"
+action = "skip"
+[[suite.test]]
+name = "filesystem-open-errors"
+action = "skip"
+[[suite.test]]
+name = "filesystem-read-directory"
+action = "skip"
+[[suite.test]]
+name = "filesystem-rename"
+action = "skip"
+[[suite.test]]
+name = "filesystem-set-size"
+action = "skip"
+[[suite.test]]
+name = "filesystem-stat"
+action = "skip"
+[[suite.test]]
+name = "filesystem-unlink-errors"
+action = "skip"
+[[suite.test]]
+name = "http-fields"
+action = "skip"
+[[suite.test]]
+name = "http-request"
+action = "skip"
+[[suite.test]]
+name = "http-response"
+action = "skip"
+[[suite.test]]
+name = "http-service"
+action = "skip"
+[[suite.test]]
+name = "monotonic-clock"
+action = "skip"
+[[suite.test]]
+name = "multi-clock-wait"
+action = "skip"
+[[suite.test]]
+name = "random"
+action = "skip"
+[[suite.test]]
+name = "run-with-err"
+action = "skip"
+[[suite.test]]
+name = "sockets-echo"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-listen"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-send"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-send"
+action = "skip"
+[[suite.test]]
+name = "wall-clock"
+action = "skip"

--- a/expectations/wasmtime/windows.toml
+++ b/expectations/wasmtime/windows.toml
@@ -15,3 +15,129 @@ action = "skip"
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
+
+# TODO(wasi-0.3.0): temporary skip during the WASI 0.3.0 chicken/egg period.
+# The wasip3 suite was bumped to the WASI 0.3.0 release, but no published
+# wasmtime release supports 0.3.0 yet (only the rc). Re-enable by deleting the
+# skips below once a wasmtime release ships WASI 0.3.0 support.
+
+[[suite.test]]
+name = "cli-env"
+action = "skip"
+[[suite.test]]
+name = "cli-exit"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio"
+action = "skip"
+[[suite.test]]
+name = "cli-stdio-roundtrip"
+action = "skip"
+[[suite.test]]
+name = "cli-terminal"
+action = "skip"
+[[suite.test]]
+name = "filesystem-advise"
+action = "skip"
+[[suite.test]]
+name = "filesystem-dotdot"
+action = "skip"
+[[suite.test]]
+name = "filesystem-flags-and-type"
+action = "skip"
+[[suite.test]]
+name = "filesystem-hard-links"
+action = "skip"
+[[suite.test]]
+name = "filesystem-io"
+action = "skip"
+[[suite.test]]
+name = "filesystem-is-same-object"
+action = "skip"
+[[suite.test]]
+name = "filesystem-metadata-hash"
+action = "skip"
+[[suite.test]]
+name = "filesystem-mkdir-rmdir"
+action = "skip"
+[[suite.test]]
+name = "filesystem-open-errors"
+action = "skip"
+[[suite.test]]
+name = "filesystem-read-directory"
+action = "skip"
+[[suite.test]]
+name = "filesystem-rename"
+action = "skip"
+[[suite.test]]
+name = "filesystem-set-size"
+action = "skip"
+[[suite.test]]
+name = "filesystem-stat"
+action = "skip"
+[[suite.test]]
+name = "filesystem-unlink-errors"
+action = "skip"
+[[suite.test]]
+name = "http-fields"
+action = "skip"
+[[suite.test]]
+name = "http-request"
+action = "skip"
+[[suite.test]]
+name = "http-response"
+action = "skip"
+[[suite.test]]
+name = "http-service"
+action = "skip"
+[[suite.test]]
+name = "monotonic-clock"
+action = "skip"
+[[suite.test]]
+name = "multi-clock-wait"
+action = "skip"
+[[suite.test]]
+name = "random"
+action = "skip"
+[[suite.test]]
+name = "run-with-err"
+action = "skip"
+[[suite.test]]
+name = "sockets-echo"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-listen"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-tcp-send"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-bind"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-connect"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-properties"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-receive"
+action = "skip"
+[[suite.test]]
+name = "sockets-udp-send"
+action = "skip"
+[[suite.test]]
+name = "wall-clock"
+action = "skip"

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-dotdot.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-dotdot.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-io.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-io.rs
@@ -7,8 +7,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
   package test:test;
 
   world test {
-      include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-      include wasi:cli/command@0.3.0-rc-2026-03-15;
+      include wasi:filesystem/imports@0.3.0;
+      include wasi:cli/command@0.3.0;
   }
 ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-echo.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-echo.rs
@@ -3,8 +3,8 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world test {
-	    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
-	    include wasi:cli/command@0.3.0-rc-2026-03-15;
+	    include wasi:sockets/imports@0.3.0;
+	    include wasi:cli/command@0.3.0;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/sockets-tcp-bind.rs
@@ -3,8 +3,8 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world test {
-	    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
-	    include wasi:cli/command@0.3.0-rc-2026-03-15;
+	    include wasi:sockets/imports@0.3.0;
+	    include wasi:cli/command@0.3.0;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/cli.rs
+++ b/tests/rust/wasm32-wasip3/src/cli.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world cli-test {
-		include wasi:cli/command@0.3.0-rc-2026-03-15;
+		include wasi:cli/command@0.3.0;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/clocks.rs
+++ b/tests/rust/wasm32-wasip3/src/clocks.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world clocks-test {
-		include wasi:clocks/imports@0.3.0-rc-2026-03-15;
+		include wasi:clocks/imports@0.3.0;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/http.rs
+++ b/tests/rust/wasm32-wasip3/src/http.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world http-test {
-	    include wasi:http/service@0.3.0-rc-2026-03-15;
+	    include wasi:http/service@0.3.0;
 	}
     ",
     additional_derives: [PartialEq, Eq, Hash, Clone],

--- a/tests/rust/wasm32-wasip3/src/random.rs
+++ b/tests/rust/wasm32-wasip3/src/random.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world random-test {
-		include wasi:random/imports@0.3.0-rc-2026-03-15;
+		include wasi:random/imports@0.3.0;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/src/sockets.rs
+++ b/tests/rust/wasm32-wasip3/src/sockets.rs
@@ -3,7 +3,7 @@ wit_bindgen::generate!({
 	package wasi-testsuite:test;
 
 	world test {
-	    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
+	    include wasi:sockets/imports@0.3.0;
 	}
     ",
     features:["clocks-timezone"],

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-cli-0.3.0/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-cli-0.3.0/package.wit
@@ -1,6 +1,6 @@
-package wasi:cli@0.3.0-rc-2026-03-15;
+package wasi:cli@0.3.0;
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface environment {
   /// Get the POSIX-style environment variables.
   ///
@@ -10,23 +10,23 @@ interface environment {
   /// Morally, these are a value import, but until value imports are available
   /// in the component model, this import function should return the same
   /// values each time it is called.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-environment: func() -> list<tuple<string, string>>;
 
   /// Get the POSIX-style arguments to the program.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-arguments: func() -> list<string>;
 
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-initial-cwd: func() -> option<string>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface exit {
   /// Exit the current instance and any linked instances.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   exit: func(status: result);
 
   /// Exit the current instance and any linked instances, reporting the
@@ -37,20 +37,20 @@ interface exit {
   ///
   /// This function does not return; the effect is analogous to a trap, but
   /// without the connotation that something bad has happened.
-  @unstable(feature = cli-exit-with-code)
+  @since(version = 0.3.0)
   exit-with-code: func(status-code: u8);
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface run {
   /// Run the program.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   run: async func() -> result;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   enum error-code {
     /// Input/output error
     io,
@@ -61,7 +61,7 @@ interface types {
   }
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface stdin {
   use types.{error-code};
 
@@ -78,11 +78,11 @@ interface stdin {
   ///
   /// Multiple streams may be active at the same time. The behavior of concurrent
   /// reads is implementation-specific.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface stdout {
   use types.{error-code};
 
@@ -94,11 +94,11 @@ interface stdout {
   ///
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface stderr {
   use types.{error-code};
 
@@ -110,7 +110,7 @@ interface stderr {
   ///
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 }
 
@@ -119,10 +119,10 @@ interface stderr {
 /// In the future, this may include functions for disabling echoing,
 /// disabling input buffering so that keyboard events are sent through
 /// immediately, querying supported features, and so on.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-input {
   /// The input side of a terminal.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource terminal-input;
 }
 
@@ -131,126 +131,126 @@ interface terminal-input {
 /// In the future, this may include functions for querying the terminal
 /// size, being notified of terminal size changes, querying supported
 /// features, and so on.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-output {
   /// The output side of a terminal.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource terminal-output;
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-stdin {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use terminal-input.{terminal-input};
 
   /// If stdin is connected to a terminal, return a `terminal-input` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-stdout {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use terminal-output.{terminal-output};
 
   /// If stdout is connected to a terminal, return a `terminal-output` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-stderr {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use terminal-output.{terminal-output};
 
   /// If stderr is connected to a terminal, return a `terminal-output` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-terminal-stderr: func() -> option<terminal-output>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import environment;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import exit;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stderr;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-input;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-output;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stderr;
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/types@0.3.0;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/types@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/preopens@0.3.0-rc-2026-03-15;
-  import wasi:sockets/types@0.3.0-rc-2026-03-15;
-  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:filesystem/types@0.3.0;
+  import wasi:filesystem/preopens@0.3.0;
+  import wasi:sockets/types@0.3.0;
+  import wasi:sockets/ip-name-lookup@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 }
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world command {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import environment;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import exit;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stderr;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-input;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-output;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stderr;
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/types@0.3.0;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/types@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/preopens@0.3.0-rc-2026-03-15;
-  import wasi:sockets/types@0.3.0-rc-2026-03-15;
-  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:filesystem/types@0.3.0;
+  import wasi:filesystem/preopens@0.3.0;
+  import wasi:sockets/types@0.3.0;
+  import wasi:sockets/ip-name-lookup@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   export run;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-clocks-0.3.0/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-clocks-0.3.0/package.wit
@@ -1,10 +1,10 @@
-package wasi:clocks@0.3.0-rc-2026-03-15;
+package wasi:clocks@0.3.0;
 
 /// This interface common types used throughout wasi:clocks.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
   /// A duration of time, in nanoseconds.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type duration = u64;
 }
 
@@ -16,14 +16,14 @@ interface types {
 ///
 /// A monotonic clock is a clock which has an unspecified initial value, and
 /// successive reads of the clock will produce non-decreasing values.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface monotonic-clock {
   use types.{duration};
 
   /// A mark on a monotonic clock is a number of nanoseconds since an
   /// unspecified initial value, and can only be compared to instances from
   /// the same monotonic-clock.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type mark = u64;
 
   /// Read the current value of the clock.
@@ -35,20 +35,20 @@ interface monotonic-clock {
   /// the value of the clock in a `mark`. Consequently, implementations
   /// should ensure that the starting time is low enough to avoid the
   /// possibility of overflow in practice.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   now: func() -> mark;
 
   /// Query the resolution of the clock. Returns the duration of time
   /// corresponding to a clock tick.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-resolution: func() -> duration;
 
   /// Wait until the specified mark has occurred.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   wait-until: async func(when: mark);
 
   /// Wait for the specified duration to elapse.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   wait-for: async func(how-long: duration);
 }
 
@@ -62,7 +62,7 @@ interface monotonic-clock {
 /// monotonic, making it unsuitable for measuring elapsed time.
 ///
 /// It is intended for reporting the current date and time for humans.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface system-clock {
   use types.{duration};
 
@@ -82,7 +82,7 @@ interface system-clock {
   ///
   /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
   /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record instant {
     seconds: s64,
     nanoseconds: u32,
@@ -94,12 +94,12 @@ interface system-clock {
   /// will not necessarily produce a sequence of non-decreasing values.
   ///
   /// The nanoseconds field of the output is always less than 1000000000.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   now: func() -> instant;
 
   /// Query the resolution of the clock. Returns the smallest duration of time
   /// that the implementation permits distinguishing.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-resolution: func() -> duration;
 }
 
@@ -148,13 +148,13 @@ interface timezone {
   to-debug-string: func() -> string;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import monotonic-clock;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import system-clock;
   @unstable(feature = clocks-timezone)
   import timezone;

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-filesystem-0.3.0/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-filesystem-0.3.0/package.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.3.0-rc-2026-03-15;
+package wasi:filesystem@0.3.0;
 
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
@@ -35,19 +35,19 @@ package wasi:filesystem@0.3.0-rc-2026-03-15;
 /// store or a database instead.
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  @since(version = 0.3.0-rc-2026-03-15)
-  use wasi:clocks/system-clock@0.3.0-rc-2026-03-15.{instant};
+  @since(version = 0.3.0)
+  use wasi:clocks/system-clock@0.3.0.{instant};
 
   /// File size or length of a region within a file.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type filesize = u64;
 
   /// The type of a filesystem object referenced by a descriptor.
   ///
   /// Note: This was called `filetype` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant descriptor-type {
     /// The descriptor refers to a block device inode.
     block-device,
@@ -71,7 +71,7 @@ interface types {
   /// Descriptor flags.
   ///
   /// Note: This was called `fdflags` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   flags descriptor-flags {
     /// Read mode: Data can be read.
     read,
@@ -113,7 +113,7 @@ interface types {
   }
 
   /// Flags determining the method of how paths are resolved.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   flags path-flags {
     /// As long as the resolved path corresponds to a symbolic link, it is
     /// expanded.
@@ -121,7 +121,7 @@ interface types {
   }
 
   /// Open flags used by `open-at`.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   flags open-flags {
     /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
     create,
@@ -134,13 +134,13 @@ interface types {
   }
 
   /// Number of hard links to an inode.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type link-count = u64;
 
   /// File attributes.
   ///
   /// Note: This was called `filestat` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record descriptor-stat {
     /// File type.
     %type: descriptor-type,
@@ -167,7 +167,7 @@ interface types {
   }
 
   /// When setting a timestamp, this gives the value to set it to.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant new-timestamp {
     /// Leave the timestamp set to its previous value.
     no-change,
@@ -179,7 +179,7 @@ interface types {
   }
 
   /// A directory entry.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record directory-entry {
     /// The type of the file referred to by this directory entry.
     %type: descriptor-type,
@@ -191,7 +191,7 @@ interface types {
   /// Not all of these error codes are returned by the functions provided by this
   /// API; some are used in higher-level library layers, and others are provided
   /// merely for alignment with POSIX.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     /// Permission denied, similar to `EACCES` in POSIX.
     access,
@@ -272,7 +272,7 @@ interface types {
   }
 
   /// File or memory access pattern advisory information.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   enum advice {
     /// The application has no advice to give on its behavior with respect
     /// to the specified data.
@@ -296,7 +296,7 @@ interface types {
 
   /// A 128-bit hash value, split into parts because wasm doesn't have a
   /// 128-bit integer type.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record metadata-hash-value {
     /// 64 bits of a 128-bit hash value.
     lower: u64,
@@ -307,7 +307,7 @@ interface types {
   /// A descriptor is a reference to a filesystem object, which may be a file,
   /// directory, named pipe, special file, or other object on which filesystem
   /// calls may be made.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource descriptor {
     /// Return a stream for reading from a file.
     ///
@@ -325,7 +325,7 @@ interface types {
     /// resolves to `err` with an `error-code`.
     ///
     /// Note: This is similar to `pread` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
     /// Return a stream for writing to a file, if available.
     ///
@@ -339,7 +339,7 @@ interface types {
     /// written or an error is encountered.
     ///
     /// Note: This is similar to `pwrite` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     write-via-stream: func(data: stream<u8>, offset: filesize) -> future<result<_, error-code>>;
     /// Return a stream for appending to a file, if available.
     ///
@@ -349,12 +349,12 @@ interface types {
     /// written or an error is encountered.
     ///
     /// Note: This is similar to `write` with `O_APPEND` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     append-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
     /// Provide file advisory information on a descriptor.
     ///
     /// This is similar to `posix_fadvise` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     advise: async func(offset: filesize, length: filesize, advice: advice) -> result<_, error-code>;
     /// Synchronize the data of a file to disk.
     ///
@@ -362,7 +362,7 @@ interface types {
     /// opened for writing.
     ///
     /// Note: This is similar to `fdatasync` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     sync-data: async func() -> result<_, error-code>;
     /// Get flags associated with a descriptor.
     ///
@@ -370,7 +370,7 @@ interface types {
     ///
     /// Note: This returns the value that was the `fs_flags` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-flags: async func() -> result<descriptor-flags, error-code>;
     /// Get the dynamic type of a descriptor.
     ///
@@ -382,20 +382,20 @@ interface types {
     ///
     /// Note: This returns the value that was the `fs_filetype` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-type: async func() -> result<descriptor-type, error-code>;
     /// Adjust the size of an open file. If this increases the file's size, the
     /// extra bytes are filled with zeros.
     ///
     /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-size: async func(size: filesize) -> result<_, error-code>;
     /// Adjust the timestamps of an open file or directory.
     ///
     /// Note: This is similar to `futimens` in POSIX.
     ///
     /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-times: async func(data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
     /// Read directory entries from a directory.
     ///
@@ -409,7 +409,7 @@ interface types {
     ///
     /// This function returns a future, which will resolve to an error code if
     /// reading full contents of the directory fails.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     read-directory: func() -> tuple<stream<directory-entry>, future<result<_, error-code>>>;
     /// Synchronize the data and metadata of a file to disk.
     ///
@@ -417,12 +417,12 @@ interface types {
     /// opened for writing.
     ///
     /// Note: This is similar to `fsync` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     sync: async func() -> result<_, error-code>;
     /// Create a directory.
     ///
     /// Note: This is similar to `mkdirat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     create-directory-at: async func(path: string) -> result<_, error-code>;
     /// Return the attributes of an open file or directory.
     ///
@@ -433,7 +433,7 @@ interface types {
     /// modified, use `metadata-hash`.
     ///
     /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     stat: async func() -> result<descriptor-stat, error-code>;
     /// Return the attributes of a file or directory.
     ///
@@ -442,7 +442,7 @@ interface types {
     /// discussion of alternatives.
     ///
     /// Note: This was called `path_filestat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     stat-at: async func(path-flags: path-flags, path: string) -> result<descriptor-stat, error-code>;
     /// Adjust the timestamps of a file or directory.
     ///
@@ -450,7 +450,7 @@ interface types {
     ///
     /// Note: This was called `path_filestat_set_times` in earlier versions of
     /// WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-times-at: async func(path-flags: path-flags, path: string, data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
     /// Create a hard link.
     ///
@@ -459,7 +459,7 @@ interface types {
     /// `error-code::not-permitted` if the old path is not a file.
     ///
     /// Note: This is similar to `linkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     link-at: async func(old-path-flags: path-flags, old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
     /// Open a file or directory.
     ///
@@ -473,7 +473,7 @@ interface types {
     /// `error-code::read-only`.
     ///
     /// Note: This is similar to `openat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     open-at: async func(path-flags: path-flags, path: string, open-flags: open-flags, %flags: descriptor-flags) -> result<descriptor, error-code>;
     /// Read the contents of a symbolic link.
     ///
@@ -481,19 +481,19 @@ interface types {
     /// filesystem, this function fails with `error-code::not-permitted`.
     ///
     /// Note: This is similar to `readlinkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     readlink-at: async func(path: string) -> result<string, error-code>;
     /// Remove a directory.
     ///
     /// Return `error-code::not-empty` if the directory is not empty.
     ///
     /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     remove-directory-at: async func(path: string) -> result<_, error-code>;
     /// Rename a filesystem object.
     ///
     /// Note: This is similar to `renameat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     rename-at: async func(old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
     /// Create a symbolic link (also known as a "symlink").
     ///
@@ -501,7 +501,7 @@ interface types {
     /// `error-code::not-permitted`.
     ///
     /// Note: This is similar to `symlinkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     symlink-at: async func(old-path: string, new-path: string) -> result<_, error-code>;
     /// Unlink a filesystem object that is not a directory.
     ///
@@ -512,7 +512,7 @@ interface types {
     /// If the filesystem object is a directory, `error-code::access` or
     /// `error-code::is-directory` may be returned instead of the
     /// POSIX-specified `error-code::not-permitted`.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     unlink-file-at: async func(path: string) -> result<_, error-code>;
     /// Test whether two descriptors refer to the same filesystem object.
     ///
@@ -520,7 +520,7 @@ interface types {
     /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
     /// wasi-filesystem does not expose device and inode numbers, so this function
     /// may be used instead.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     is-same-object: async func(other: borrow<descriptor>) -> bool;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a descriptor.
@@ -541,35 +541,35 @@ interface types {
     ///    computed hash.
     ///
     /// However, none of these is required.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     metadata-hash: async func() -> result<metadata-hash-value, error-code>;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a directory descriptor and a relative path.
     ///
     /// This performs the same hash computation as `metadata-hash`.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     metadata-hash-at: async func(path-flags: path-flags, path: string) -> result<metadata-hash-value, error-code>;
   }
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface preopens {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use types.{descriptor};
 
   /// Return the set of preopened directories, and their paths.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-directories: func() -> list<tuple<descriptor, string>>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  @since(version = 0.3.0-rc-2026-03-15)
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
+  import wasi:clocks/types@0.3.0;
+  @since(version = 0.3.0)
+  import wasi:clocks/system-clock@0.3.0;
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import preopens;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-http-0.3.0/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-http-0.3.0/package.wit
@@ -1,13 +1,13 @@
-package wasi:http@0.3.0-rc-2026-03-15;
+package wasi:http@0.3.0;
 
 /// This interface defines all of the types and methods for implementing HTTP
 /// Requests and Responses, as well as their headers, trailers, and bodies.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  use wasi:clocks/types@0.3.0-rc-2026-03-15.{duration};
+  use wasi:clocks/types@0.3.0.{duration};
 
   /// This type corresponds to HTTP standard Methods.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant method {
     get,
     head,
@@ -22,7 +22,7 @@ interface types {
   }
 
   /// This type corresponds to HTTP standard Related Schemes.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant scheme {
     HTTP,
     HTTPS,
@@ -30,21 +30,21 @@ interface types {
   }
 
   /// Defines the case payload type for `DNS-error` above:
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record DNS-error-payload {
     rcode: option<string>,
     info-code: option<u16>,
   }
 
   /// Defines the case payload type for `TLS-alert-received` above:
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record TLS-alert-received-payload {
     alert-id: option<u8>,
     alert-message: option<string>,
   }
 
   /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record field-size-payload {
     field-name: option<string>,
     field-size: option<u32>,
@@ -52,7 +52,7 @@ interface types {
 
   /// These cases are inspired by the IANA HTTP Proxy Error Types:
   ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),
@@ -102,7 +102,7 @@ interface types {
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant header-error {
     /// This error indicates that a `field-name` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
@@ -130,7 +130,7 @@ interface types {
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting fields of a `request-options` resource.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant request-options-error {
     /// Indicates the specified field is not supported by this implementation.
     not-supported,
@@ -150,13 +150,13 @@ interface types {
   ///
   /// Field names should always be treated as case insensitive by the `fields`
   /// resource for the purposes of equality checking.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type field-name = string;
 
   /// Field values should always be ASCII strings. However, in
   /// reality, HTTP implementations often have to interpret malformed values,
   /// so they are provided as a list of bytes.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type field-value = list<u8>;
 
   /// This following block defines the `fields` resource which corresponds to
@@ -178,7 +178,7 @@ interface types {
   /// Implementations may impose limits on individual field values and on total
   /// aggregate field section size. Operations that would exceed these limits
   /// fail with `header-error.size-exceeded`
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource fields {
     /// Construct an empty HTTP Fields.
     ///
@@ -254,15 +254,15 @@ interface types {
   }
 
   /// Headers is an alias for Fields.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type headers = fields;
 
   /// Trailers is an alias for Fields.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type trailers = fields;
 
   /// Represents an HTTP Request.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource request {
     /// Construct a new `request` with a default `method` of `GET`, and
     /// `none` values for `path-with-query`, `scheme`, and `authority`.
@@ -349,7 +349,7 @@ interface types {
   ///
   /// These timeouts are separate from any the user may use to bound an
   /// asynchronous call.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource request-options {
     /// Construct a default `request-options` value.
     constructor();
@@ -378,11 +378,11 @@ interface types {
   }
 
   /// This type corresponds to the HTTP standard Status Code.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type status-code = u16;
 
   /// Represents an HTTP Response.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource response {
     /// Construct a new `response`, with a default `status-code` of `200`.
     /// If a different `status-code` is needed, it must be set via the
@@ -431,7 +431,7 @@ interface types {
 ///
 /// In `wasi:http/middleware` this interface is both exported and imported as
 /// the "downstream" and "upstream" directions of the middleware chain.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface handler {
   use types.{request, response, error-code};
 
@@ -450,7 +450,7 @@ interface handler {
 /// (including WIT itself) is unable to represent a component importing two
 /// instances of the same interface. A `client.send` import may be linked
 /// directly to a `handler.handle` export to bypass the network.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface client {
   use types.{request, response, error-code};
 
@@ -462,22 +462,22 @@ interface client {
 /// The `wasi:http/service` world captures a broad category of HTTP services
 /// including web applications, API servers, and proxies. It may be `include`d
 /// in more specific worlds such as `wasi:http/middleware`.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world service {
-  import wasi:cli/types@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdout@0.3.0-rc-2026-03-15;
-  import wasi:cli/stderr@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdin@0.3.0-rc-2026-03-15;
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  import wasi:cli/types@0.3.0;
+  import wasi:cli/stdout@0.3.0;
+  import wasi:cli/stderr@0.3.0;
+  import wasi:cli/stdin@0.3.0;
+  import wasi:clocks/types@0.3.0;
   import types;
   import client;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 
   export handler;
 }
@@ -487,23 +487,23 @@ world service {
 /// Components may implement this world to allow them to participate in handler
 /// "chains" where a `request` flows through handlers on its way to some terminal
 /// `service` and corresponding `response` flows in the opposite direction.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world middleware {
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  import wasi:clocks/types@0.3.0;
   import types;
   import handler;
-  import wasi:cli/types@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdout@0.3.0-rc-2026-03-15;
-  import wasi:cli/stderr@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdin@0.3.0-rc-2026-03-15;
+  import wasi:cli/types@0.3.0;
+  import wasi:cli/stdout@0.3.0;
+  import wasi:cli/stderr@0.3.0;
+  import wasi:cli/stdin@0.3.0;
   import client;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 
   export handler;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-random-0.3.0/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-random-0.3.0/package.wit
@@ -1,10 +1,10 @@
-package wasi:random@0.3.0-rc-2026-03-15;
+package wasi:random@0.3.0;
 
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface insecure-seed {
   /// Return a 128-bit value that may contain a pseudo-random value.
   ///
@@ -23,7 +23,7 @@ interface insecure-seed {
   /// This will likely be changed to a value import, to prevent it from being
   /// called multiple times and potentially used for purposes other than DoS
   /// protection.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-insecure-seed: func() -> tuple<u64, u64>;
 }
 
@@ -31,7 +31,7 @@ interface insecure-seed {
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface insecure {
   /// Return up to `max-len` insecure pseudo-random bytes.
   ///
@@ -48,14 +48,14 @@ interface insecure {
   /// Implementations MUST return at least 1 byte when `max-len` is greater
   /// than zero. When `max-len` is zero, implementations MUST return an empty
   /// list without trapping.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-insecure-random-bytes: func(max-len: u64) -> list<u8>;
 
   /// Return an insecure pseudo-random `u64` value.
   ///
   /// This function returns the same type of pseudo-random data as
   /// `get-insecure-random-bytes`, represented as a `u64`.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-insecure-random-u64: func() -> u64;
 }
 
@@ -63,7 +63,7 @@ interface insecure {
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface random {
   /// Return up to `max-len` cryptographically-secure random or pseudo-random
   /// bytes.
@@ -85,23 +85,23 @@ interface random {
   /// This function must always return fresh data. Deterministic environments
   /// must omit this function, rather than implementing it with deterministic
   /// data.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-random-bytes: func(max-len: u64) -> list<u8>;
 
   /// Return a cryptographically-secure random or pseudo-random `u64` value.
   ///
   /// This function returns the same type of data as `get-random-bytes`,
   /// represented as a `u64`.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-random-u64: func() -> u64;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import random;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import insecure;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import insecure-seed;
 }

--- a/tests/rust/wasm32-wasip3/wit/deps/wasi-sockets-0.3.0/package.wit
+++ b/tests/rust/wasm32-wasip3/wit/deps/wasi-sockets-0.3.0/package.wit
@@ -1,9 +1,9 @@
-package wasi:sockets@0.3.0-rc-2026-03-15;
+package wasi:sockets@0.3.0;
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  @since(version = 0.3.0-rc-2026-03-15)
-  use wasi:clocks/types@0.3.0-rc-2026-03-15.{duration};
+  @since(version = 0.3.0)
+  use wasi:clocks/types@0.3.0.{duration};
 
   /// Error codes.
   ///
@@ -16,7 +16,7 @@ interface types {
   /// - `out-of-memory`
   ///
   /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     /// Access denied.
     ///
@@ -80,7 +80,7 @@ interface types {
     other(option<string>),
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   enum ip-address-family {
     /// Similar to `AF_INET` in POSIX.
     ipv4,
@@ -88,19 +88,19 @@ interface types {
     ipv6,
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type ipv4-address = tuple<u8, u8, u8, u8>;
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant ip-address {
     ipv4(ipv4-address),
     ipv6(ipv6-address),
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record ipv4-socket-address {
     /// sin_port
     port: u16,
@@ -108,7 +108,7 @@ interface types {
     address: ipv4-address,
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record ipv6-socket-address {
     /// sin6_port
     port: u16,
@@ -120,7 +120,7 @@ interface types {
     scope-id: u32,
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant ip-socket-address {
     ipv4(ipv4-socket-address),
     ipv6(ipv6-socket-address),
@@ -135,7 +135,7 @@ interface types {
   /// - `connecting`
   /// - `connected`
   /// - `closed`
-  /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics-0.3.0-draft.md>
+  /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics-0.3.0.md>
   /// for more information.
   ///
   /// Note: Except where explicitly mentioned, whenever this documentation uses
@@ -158,7 +158,7 @@ interface types {
   /// In addition to the general error codes documented on the
   /// `types::error-code` type, TCP socket methods may always return
   /// `error(invalid-state)` when in the `closed` state.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource tcp-socket {
     /// Create a new TCP socket.
     ///
@@ -178,7 +178,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     create: static func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
     /// Bind the socket to the provided IP address and port.
     ///
@@ -213,7 +213,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     bind: func(local-address: ip-socket-address) -> result<_, error-code>;
     /// Connect to a remote endpoint.
     ///
@@ -249,7 +249,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
     /// Start listening and return a stream of new inbound connections.
     ///
@@ -321,7 +321,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     listen: func() -> result<stream<tcp-socket>, error-code>;
     /// Transmit data to peer.
     ///
@@ -345,7 +345,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/send.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     send: func(data: stream<u8>) -> future<result<_, error-code>>;
     /// Read data from peer.
     ///
@@ -374,7 +374,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     receive: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
     /// Get the bound local address.
     ///
@@ -393,7 +393,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-local-address: func() -> result<ip-socket-address, error-code>;
     /// Get the remote address.
     ///
@@ -405,19 +405,19 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-remote-address: func() -> result<ip-socket-address, error-code>;
     /// Whether the socket is in the `listening` state.
     ///
     /// Equivalent to the SO_ACCEPTCONN socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-is-listening: func() -> bool;
     /// Whether this is a IPv4 or IPv6 socket.
     ///
     /// This is the value passed to the constructor.
     ///
     /// Equivalent to the SO_DOMAIN socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-address-family: func() -> ip-address-family;
     /// Hints the desired listen queue size. Implementations are free to
     /// ignore this.
@@ -430,7 +430,7 @@ interface types {
     /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
     /// - `invalid-argument`:     (set) The provided value was 0.
     /// - `invalid-state`:        (set) The socket is in the `connecting` or `connected` state.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
     /// Enables or disables keepalive.
     ///
@@ -442,9 +442,9 @@ interface types {
     /// false, but only come into effect when `keep-alive-enabled` is true.
     ///
     /// Equivalent to the SO_KEEPALIVE socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-enabled: func() -> result<bool, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-enabled: func(value: bool) -> result<_, error-code>;
     /// Amount of time the connection has to be idle before TCP starts
     /// sending keepalive packets.
@@ -458,9 +458,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-idle-time: func() -> result<duration, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-idle-time: func(value: duration) -> result<_, error-code>;
     /// The time between keepalive packets.
     ///
@@ -473,9 +473,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-interval: func() -> result<duration, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-interval: func(value: duration) -> result<_, error-code>;
     /// The maximum amount of keepalive packets TCP should send before
     /// aborting the connection.
@@ -489,9 +489,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-count: func() -> result<u32, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-count: func(value: u32) -> result<_, error-code>;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     ///
@@ -499,9 +499,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-hop-limit: func() -> result<u8, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-hop-limit: func(value: u8) -> result<_, error-code>;
     /// Kernel buffer space reserved for sending/receiving on this socket.
     /// Implementations usually treat this as a cap the buffer can grow to,
@@ -524,18 +524,18 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-receive-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-send-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-send-buffer-size: func(value: u64) -> result<_, error-code>;
   }
 
   /// A UDP socket handle.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource udp-socket {
     /// Create a new UDP socket.
     ///
@@ -552,7 +552,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     create: static func(address-family: ip-address-family) -> result<udp-socket, error-code>;
     /// Bind the socket to the provided IP address and port.
     ///
@@ -573,7 +573,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     bind: func(local-address: ip-socket-address) -> result<_, error-code>;
     /// Associate this socket with a specific peer address.
     ///
@@ -611,7 +611,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     connect: func(remote-address: ip-socket-address) -> result<_, error-code>;
     /// Dissociate this socket from its peer address.
     ///
@@ -628,7 +628,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     disconnect: func() -> result<_, error-code>;
     /// Send a message on the socket to a particular peer.
     ///
@@ -672,7 +672,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     send: async func(data: list<u8>, remote-address: option<ip-socket-address>) -> result<_, error-code>;
     /// Receive a message on the socket.
     ///
@@ -697,7 +697,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_wsarecvmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     receive: async func() -> result<tuple<list<u8>, ip-socket-address>, error-code>;
     /// Get the current bound address.
     ///
@@ -716,7 +716,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-local-address: func() -> result<ip-socket-address, error-code>;
     /// Get the address the socket is currently "connected" to.
     ///
@@ -728,14 +728,14 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-remote-address: func() -> result<ip-socket-address, error-code>;
     /// Whether this is a IPv4 or IPv6 socket.
     ///
     /// This is the value passed to the constructor.
     ///
     /// Equivalent to the SO_DOMAIN socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-address-family: func() -> ip-address-family;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     ///
@@ -743,9 +743,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-unicast-hop-limit: func() -> result<u8, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
     /// Kernel buffer space reserved for sending/receiving on this socket.
     /// Implementations usually treat this as a cap the buffer can grow to,
@@ -760,24 +760,24 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-receive-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-send-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-send-buffer-size: func(value: u64) -> result<_, error-code>;
   }
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface ip-name-lookup {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use types.{ip-address};
 
   /// Lookup error codes.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     /// Access denied.
     ///
@@ -824,16 +824,16 @@ interface ip-name-lookup {
   /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
   /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
   /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resolve-addresses: async func(name: string) -> result<list<ip-address>, error-code>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
+  import wasi:clocks/types@0.3.0;
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import ip-name-lookup;
 }

--- a/tests/rust/wasm32-wasip3/wit/wasi.wit
+++ b/tests/rust/wasm32-wasip3/wit/wasi.wit
@@ -1,10 +1,10 @@
 package test:wasip3;
 
 world wasip3 {
-    include wasi:cli/command@0.3.0-rc-2026-03-15;
-    include wasi:clocks/imports@0.3.0-rc-2026-03-15;
-    include wasi:filesystem/imports@0.3.0-rc-2026-03-15;
-    include wasi:http/middleware@0.3.0-rc-2026-03-15;
-    include wasi:random/imports@0.3.0-rc-2026-03-15;
-    include wasi:sockets/imports@0.3.0-rc-2026-03-15;
+    include wasi:cli/command@0.3.0;
+    include wasi:clocks/imports@0.3.0;
+    include wasi:filesystem/imports@0.3.0;
+    include wasi:http/middleware@0.3.0;
+    include wasi:random/imports@0.3.0;
+    include wasi:sockets/imports@0.3.0;
 }

--- a/tests/rust/wasm32-wasip3/wkg.lock
+++ b/tests/rust/wasm32-wasip3/wkg.lock
@@ -7,51 +7,51 @@ name = "wasi:cli"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-03-15"
-version = "0.3.0-rc-2026-03-15"
-digest = "sha256:104654cfcb218c34c21ea06ab95f0d6811508643e9692bb3db751cde5640365f"
+requirement = "=0.3.0"
+version = "0.3.0"
+digest = "sha256:3a2d58743b67a057f7210b9a73d3b21b34ec7895ffe34d1cb092927307156e40"
 
 [[packages]]
 name = "wasi:clocks"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-03-15"
-version = "0.3.0-rc-2026-03-15"
-digest = "sha256:10f8b2f42c5f8a731292977064788cbb8ca9164c83ae7f4a295565e7b926a313"
+requirement = "=0.3.0"
+version = "0.3.0"
+digest = "sha256:59e1f4079e64ada450e19ffc9d08854c904e356ed8cc1fda36ff4fe150264db2"
 
 [[packages]]
 name = "wasi:filesystem"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-03-15"
-version = "0.3.0-rc-2026-03-15"
-digest = "sha256:d8e683409e17bbe06ce6560b67dc19414e6b21f62e88f22ca436f8967dfde188"
+requirement = "=0.3.0"
+version = "0.3.0"
+digest = "sha256:42921410cddcdce2e009fd65c9a763bfb3fb61e2c0a64ff71647cc4405470378"
 
 [[packages]]
 name = "wasi:http"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-03-15"
-version = "0.3.0-rc-2026-03-15"
-digest = "sha256:ed996ba07af24b216deb3d59bf56362f443d8bcfd1b07d1bfd80c49cb37df399"
+requirement = "=0.3.0"
+version = "0.3.0"
+digest = "sha256:92cd8f3730c00226dc15626a2e7b21834dd187fc221f09818720d228585bbbf7"
 
 [[packages]]
 name = "wasi:random"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-03-15"
-version = "0.3.0-rc-2026-03-15"
-digest = "sha256:821a5c015d3833f748fb00f2279d4fccc360d38f204f37f7ae2af904fc1f7f13"
+requirement = "=0.3.0"
+version = "0.3.0"
+digest = "sha256:daa3c8897a68fbfc58b95c2e1de1b7af5be8c647bbb2cfeaa54c1e5b1ba9b772"
 
 [[packages]]
 name = "wasi:sockets"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.3.0-rc-2026-03-15"
-version = "0.3.0-rc-2026-03-15"
-digest = "sha256:9944ecbee9950744290bb1ccb134aa2fc9821307fd6016cb01e6d617bc382cfe"
+requirement = "=0.3.0"
+version = "0.3.0"
+digest = "sha256:47d4cb10ad41dbd7f543693211876bf413793d4d8dc0aad08ead34bf44348fa1"

--- a/tools/jco_runner.mjs
+++ b/tools/jco_runner.mjs
@@ -5,7 +5,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 
-const WASI_CLI_RUN_EXPORT = "wasi:cli/run@0.3.0-rc-2026-03-15";
+const WASI_CLI_RUN_EXPORT = "wasi:cli/run@0.3.0";
 
 function parseArgs(argv) {
   const options = {};


### PR DESCRIPTION
The wasip3 packages are now officially released as 0.3.0!

Replace the release candidate with the v0.3.0 release.

NOTE: wait for wasmtime and jco to vendor 0.3.0 support.