### PR TITLE
Refactor filesystem tests to have a root directory

### DIFF
--- a/adapters/jco.py
+++ b/adapters/jco.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 
 # shlex.split() splits according to shell quoting rules.
@@ -37,18 +37,17 @@ def get_timeout_seconds() -> float:
 
 
 def compute_argv(test_path: str,
-                 args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+                 args_env_root: Tuple[List[str], Dict[str, str], Optional[str]],
                  proposals: List[str],
                  wasi_world: str,
                  wasi_version: str) -> List[str]:
-    args, env, dirs = args_env_dirs
-    preopens = [
-        {
-            "guest": guest,
-            "host": str(host),
-        }
-        for host, guest in dirs
-    ]
+    args, env, root = args_env_root
+    preopens = []
+    if root:
+        preopens.append({
+            "guest": "/",
+            "host": str(root),
+        })
 
     return JCO + [
         "--component", test_path,

--- a/adapters/pywasm.py
+++ b/adapters/pywasm.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 import importlib
 
 
@@ -33,20 +33,20 @@ def get_wasi_worlds() -> List[str]:
 
 
 def compute_argv(test_path: str,
-                 args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+                 args_env_root: Tuple[List[str], Dict[str, str], Optional[str]],
                  proposals: List[str],
                  wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []
     argv += [str(RUN_PYWASM)]
-    args, env, dirs = args_env_dirs
+    args, env, root = args_env_root
 
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]
 
-    for host, guest in dirs:
-        argv += ["--dir", f"{host}::{guest}"]  # noqa: E231
+    if root:
+        argv += ["--dir", f"{root}::/"]  # noqa: E231
 
     argv += [test_path]
 

--- a/adapters/wasm-micro-runtime.py
+++ b/adapters/wasm-micro-runtime.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 import importlib
 
 
@@ -34,20 +34,20 @@ def get_wasi_worlds() -> List[str]:
 
 
 def compute_argv(test_path: str,
-                 args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+                 args_env_root: Tuple[List[str], Dict[str, str], Optional[str]],
                  proposals: List[str],
                  wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []
     argv += IWASM
-    args, env, dirs = args_env_dirs
+    args, env, root = args_env_root
 
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]
 
-    for host, guest in dirs:
-        argv += [f"--map-dir={guest}::{host}"]  # noqa: E231
+    if root:
+        argv += [f"--map-dir=/::{root}"]  # noqa: E231
 
     argv += [test_path]
 

--- a/adapters/wasmedge.py
+++ b/adapters/wasmedge.py
@@ -34,20 +34,20 @@ def get_wasi_worlds() -> List[str]:
 
 
 def compute_argv(test_path: str,
-                 args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+                 args_env_root: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
                  proposals: List[str],
                  wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []
     argv += WASMEDGE
-    args, env, dirs = args_env_dirs
+    args, env, root = args_env_root
 
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]
 
-    for host, guest in dirs:
-        argv += ["--dir", f"{guest}:{host}"]
+    if root:
+        argv += ["--dir", f"/:{root}"]
 
     argv += [test_path]
 

--- a/adapters/wasmtime.py
+++ b/adapters/wasmtime.py
@@ -2,7 +2,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 # shlex.split() splits according to shell quoting rules
 WASMTIME = shlex.split(os.getenv("WASMTIME", "wasmtime"), posix=os.name != "nt")
@@ -30,20 +30,20 @@ def get_wasi_worlds() -> List[str]:
 
 
 def compute_argv(test_path: str,
-                 args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+                 args_env_root: Tuple[List[str], Dict[str, str], Optional[str]],
                  proposals: List[str],
                  wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []
     argv += WASMTIME
-    args, env, dirs = args_env_dirs
+    args, env, root = args_env_root
 
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]
 
-    for host, guest in dirs:
-        argv += ["--dir", f"{host}::{guest}"]  # noqa: E231
+    if root:
+        argv += ["--dir", f"{root}::/"]  # noqa: E231
 
     argv += [test_path]
 

--- a/adapters/wazero.py
+++ b/adapters/wazero.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 import importlib
 
 
@@ -36,7 +36,7 @@ def get_wasi_worlds() -> List[str]:
 
 
 def compute_argv(test_path: str,
-                 args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+                 args_env_root: Tuple[List[str], Dict[str, str], Optional[str]],
                  proposals: List[str],
                  wasi_world: str,
                  wasi_version: str) -> List[str]:
@@ -44,13 +44,13 @@ def compute_argv(test_path: str,
     argv = []
     argv += WAZERO
     argv += ["run", "-hostlogging=filesystem"]
-    args, env, dirs = args_env_dirs
+    args, env, root = args_env_root
 
     for k, v in env.items():
         argv += [f"-env={k}={v}"]
 
-    for host, guest in dirs:
-        argv += [f"-mount={host}:{guest}"]
+    if root:
+        argv += [f"-mount={root}:/"]
 
     argv += [test_path]
 

--- a/adapters/wizard.py
+++ b/adapters/wizard.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 import importlib
 
 
@@ -41,21 +41,21 @@ def get_wasi_worlds() -> List[str]:
 
 
 def compute_argv(test_path: str,
-                 args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+                 args_env_root: Tuple[List[str], Dict[str, str], Optional[str]],
                  proposals: List[str],
                  wasi_world: str,
                  wasi_version: str) -> List[str]:
 
     argv = []
     argv += WIZARD
-    args, env, dirs = args_env_dirs
+    args, env, root = args_env_root
 
     for k, v in env.items():
         argv += [f"--env={k}={v}"]
 
-    for host, guest in dirs:
+    if root:
         # FIXME: https://github.com/titzer/wizard-engine/issues/482
-        argv += [f"--dir={host}"]
+        argv += [f"--dir={root}"]
 
     argv += [test_path]
 

--- a/doc/specification.md
+++ b/doc/specification.md
@@ -28,7 +28,7 @@ These are the default values for the legacy configuration specification:
   ```json
   {
     "args": [],
-    "dirs": [],
+    "root": null,
     "env": {},
     "exit_code": 0,
     "stderr": "",
@@ -70,7 +70,8 @@ Defines how to start the execution of the test case.
 **Fields:**
 - `args` (optional): List of command-line arguments to pass to the WASI program
 - `env` (optional): Dictionary of environment variables (key-value pairs)
-- `dirs` (optional): List of directory paths to preopen
+- `root` (optional): Path, relative to the test's directory, of a directory to
+  preopen as the WASI guest's root filesystem (`/`)
 
 **Default values:**
 ```json
@@ -78,7 +79,7 @@ Defines how to start the execution of the test case.
   "type": "run",
   "args": [],
   "env": {},
-  "dirs": []
+  "root": null
 }
 ```
 
@@ -212,8 +213,8 @@ To execute the tests, the test executor is expected to:
   contain these keys and otherwise should be empty (note that this environment is the WASI
   environment, whether the engine inherits the shell environment or explicitly configures it via
   `--env` parameters)
-- `dir`: add each path listed in `dir` as WASI preopen directories (some engines use a `--dir`
-  flag)
+- `root`: if set, preopen this directory as the WASI guest's root filesystem (`/`); some engines
+  use a `--dir host::/` flag for this
 - `args`: pass each argument in order to the WASI program (most CLI engines allow appending these
   after the module path)
 - `proposals`: pass the right flags to enable each WASI proposal.

--- a/doc/writing-tests.md
+++ b/doc/writing-tests.md
@@ -35,8 +35,8 @@ regarding `stat`, for WASIp3, in Rust.  Well then you need to add your
 and it will be automatically built.  (How?  We'll come back to that.)
 
 What does your test need?  If you are testing `stat`, probably you need
-a file, so the WASI module is going to need to start with a preopened
-directory.  Make the directory, say call it `stat-working-dir`, as a
+a file, so the WASI module is going to need to start with a root
+filesystem.  Make the directory, say call it `stat-working-dir`, as a
 subfolder of the directory your test is in.  Then create a
 `filesystem-stat-subtlety.json` in the test directory:
 
@@ -45,19 +45,19 @@ subfolder of the directory your test is in.  Then create a
   "operations": [
     {
 	  "type": "run",
-	  "dirs": ["stat-working-dir"]
+	  "root": "stat-working-dir"
 	}
   ]
 }
 ```
 
-A `dirs` declaration in the `run` operation of a test's JSON file adds
-a dir to the preopens.
+A `root` declaration in the `run` operation of a test's JSON file
+preopens that directory as the WASI guest's root filesystem (`/`).
 
 If you need to create a file, name it something that ends with
 `.cleanup`, if possible, and ideally have the test case remove it at the
-end.  But just in case, the test runner will delete files in a test's
-`dirs` with names like that, both before and after running the test.
+end.  But just in case, the test runner will delete files under a test's
+`root` with names like that, both before and after running the test.
 
 
 ## Building tests

--- a/expectations/wamr/linux.toml
+++ b/expectations/wamr/linux.toml
@@ -12,3 +12,11 @@ action = "skip"
 [[suite.test]]
 name = "environ_sizes_get-multiple-variables"
 action = "skip"
+
+[[suite]]
+name = "WASI Rust tests [wasm32-wasip1]"
+
+# WAMR differs for this Preview 1 Rust test
+[[suite.test]]
+name = "symlink_create"
+action = "skip"

--- a/test-runner/tests/test_test_case.py
+++ b/test-runner/tests/test_test_case.py
@@ -21,7 +21,7 @@ def test_test_config_should_load_defaults_for_empty_json(_mock_file: Mock) -> No
     run = config.operations[0]
     assert isinstance(run, Run)
     assert run.args == []
-    assert run.dirs == []
+    assert run.root is None
     assert run.env == {}
 
     wait = config.operations[1]
@@ -41,7 +41,7 @@ def test_test_config_should_load_values_from_json(_mock_file: Mock) -> None:
     run = config.operations[0]
     assert isinstance(run, Run)
     assert run.args == ["a", "b"]
-    assert run.dirs == []
+    assert run.root is None
     assert run.env == {}
 
     wait = config.operations[1]
@@ -89,22 +89,20 @@ def test_run_from_config_with_defaults() -> None:
 
     assert run.args == []
     assert run.env == {}
-    assert run.dirs == []
+    assert run.root is None
 
 
 def test_run_from_config_with_values() -> None:
     config = {
         "args": ["arg1", "arg2"],
         "env": {"KEY": "value"},
-        "dirs": [".", "subdir"]
+        "root": "workdir"
     }
     run = Run.from_config(Path("/test/path"), config)
 
     assert run.args == ["arg1", "arg2"]
     assert run.env == {"KEY": "value"}
-    assert len(run.dirs) == 2
-    assert all(isinstance(d, tuple) and len(d) == 2 for d in run.dirs)
-    assert all(isinstance(d[0], Path) and isinstance(d[1], str) for d in run.dirs)
+    assert run.root == Path("/test/workdir")
 
 
 def test_wait_from_config_with_defaults() -> None:

--- a/test-runner/tests/test_test_suite_runner.py
+++ b/test-runner/tests/test_test_suite_runner.py
@@ -61,7 +61,7 @@ def test_runner_end_to_end() -> None:
     expected_config = [
         tc.Config(
             operations=[
-                tc.Run(root=test_suite_root / test_root),
+                tc.Run(root=Path(test_suite_dir) / test_root),
                 tc.Wait(exit_code=0)
             ],
             proposals=[],

--- a/test-runner/tests/test_test_suite_runner.py
+++ b/test-runner/tests/test_test_suite_runner.py
@@ -12,7 +12,7 @@ def get_mock_open() -> Mock:
     def open_mock(filename: str, *_args: Any, **_kwargs: Any) -> Any:
         file_content = {
             "my-path/manifest.json": '{"name": "test-suite"}',
-            "my-path/test1.json": '{"dirs": [".", "deep/dir"]}',
+            "my-path/test1.json": '{"root": "deep/dir"}',
             "my-path/test2.json": '{"exit_code": 1, "args": ["a", "b"]}',
             "my-path/test3.json": '{"stdout": "output", "env": {"x": "1"}}',
             "my-path/test4.json": (
@@ -48,7 +48,7 @@ def test_runner_end_to_end() -> None:
     test_files = ["test1.wasm", "test2.wasm", "test3.wasm", "test4.wasm"]
     test_paths = [Path(test_suite_dir) / f for f in test_files]
 
-    test_dirs = [".", "deep/dir"]
+    test_root = "deep/dir"
     runtime_name = "rt1"
 
     expected_argv = [runtime_name, "<test>"]
@@ -61,7 +61,7 @@ def test_runner_end_to_end() -> None:
     expected_config = [
         tc.Config(
             operations=[
-                tc.Run(dirs=[(Path(test_suite_dir) / d, d) for d in test_dirs]),
+                tc.Run(root=test_suite_root / test_root),
                 tc.Wait(exit_code=0)
             ],
             proposals=[],

--- a/test-runner/wasi_test_runner/runtime_adapter.py
+++ b/test-runner/wasi_test_runner/runtime_adapter.py
@@ -2,7 +2,7 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
-from typing import NamedTuple, List, Tuple, Dict, Any, Optional
+from typing import NamedTuple, List, Dict, Any, Optional
 
 from .test_case import WasiVersion, WasiWorld
 
@@ -110,7 +110,7 @@ class RuntimeAdapter:
     def compute_argv(self, test_path: str,
                      args: List[str],
                      env: Dict[str, str],
-                     root: Optional[str],
+                     root: Optional[Path],
                      proposals: List[str],
                      wasi_world: WasiWorld,
                      wasi_version: WasiVersion) -> List[str]:

--- a/test-runner/wasi_test_runner/runtime_adapter.py
+++ b/test-runner/wasi_test_runner/runtime_adapter.py
@@ -2,7 +2,7 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
-from typing import NamedTuple, List, Tuple, Dict, Any
+from typing import NamedTuple, List, Tuple, Dict, Any, Optional
 
 from .test_case import WasiVersion, WasiWorld
 
@@ -110,7 +110,7 @@ class RuntimeAdapter:
     def compute_argv(self, test_path: str,
                      args: List[str],
                      env: Dict[str, str],
-                     dirs: List[Tuple[Path, str]],
+                     root: Optional[str],
                      proposals: List[str],
                      wasi_world: WasiWorld,
                      wasi_version: WasiVersion) -> List[str]:
@@ -118,8 +118,8 @@ class RuntimeAdapter:
         # pylint: disable-msg=unknown-option-value
         # pylint: disable-msg=too-many-arguments
         # pylint: disable-msg=too-many-positional-arguments
-        args_env_dirs = [args, env, dirs]
-        argv = self._adapter.compute_argv(test_path, args_env_dirs,
+        args_env_root = [args, env, root]
+        argv = self._adapter.compute_argv(test_path, args_env_root,
                                           proposals, wasi_world.value,
                                           wasi_version.value)
         assert isinstance(argv, list)

--- a/test-runner/wasi_test_runner/test_case.py
+++ b/test-runner/wasi_test_runner/test_case.py
@@ -3,7 +3,7 @@ import json
 import signal
 from pathlib import Path
 from enum import Enum, StrEnum, auto
-from typing import List, NamedTuple, TypeVar, Type, Dict, Any, Set, Tuple, Optional
+from typing import List, NamedTuple, TypeVar, Type, Dict, Any, Set, Optional
 
 # Top level configuration keys
 LEGACY_CONFIG_KEYS = {"args", "root", "env", "exit_code", "stderr", "stdout"}
@@ -89,7 +89,7 @@ R = TypeVar("R", bound="Run")
 class Run(NamedTuple):
     args: List[str] = []
     env: Dict[str, str] = {}
-    root: Optional[str] = None
+    root: Optional[Path] = None
 
     @classmethod
     def from_config(cls: Type[R], test_config_path: Path, config: Dict[str, Any]) -> R:

--- a/test-runner/wasi_test_runner/test_case.py
+++ b/test-runner/wasi_test_runner/test_case.py
@@ -3,10 +3,10 @@ import json
 import signal
 from pathlib import Path
 from enum import Enum, StrEnum, auto
-from typing import List, NamedTuple, TypeVar, Type, Dict, Any, Set, Tuple
+from typing import List, NamedTuple, TypeVar, Type, Dict, Any, Set, Tuple, Optional
 
 # Top level configuration keys
-LEGACY_CONFIG_KEYS = {"args", "dirs", "env", "exit_code", "stderr", "stdout"}
+LEGACY_CONFIG_KEYS = {"args", "root", "env", "exit_code", "stderr", "stdout"}
 CONFIG_KEYS = {"operations", "proposals", "world"}
 
 
@@ -89,17 +89,18 @@ R = TypeVar("R", bound="Run")
 class Run(NamedTuple):
     args: List[str] = []
     env: Dict[str, str] = {}
-    dirs: List[Tuple[Path, str]] = []
+    root: Optional[str] = None
 
     @classmethod
     def from_config(cls: Type[R], test_config_path: Path, config: Dict[str, Any]) -> R:
         default = cls()
-        dirs = config.get("dirs", default.dirs)
-        dir_pairs = [(test_config_path.parent / d, d) for d in dirs]
+        root = config.get("root", default.root)
+        if root:
+            root = test_config_path.parent / root
         return cls(
             args=config.get("args", default.args),
             env=config.get("env", default.env),
-            dirs=dir_pairs
+            root=root
         )
 
 

--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -111,11 +111,11 @@ class TestCaseRunner(TestCaseRunnerBase):
         return self._http_server
 
     def do_run(self, run: Run) -> None:
-        for (host, _guest) in run.dirs:
-            self._add_cleanup_dir(host)
+        if run.root:
+            self._add_cleanup_dir(run.root)
         proposals = self.config.proposals_as_str()
         argv = self._runtime.compute_argv(
-            self._test_path, run.args, run.env, run.dirs, proposals,
+            self._test_path, run.args, run.env, run.root, proposals,
             self.config.world, self._wasi_version)
         self._last_argv = argv
         try:

--- a/tests/c/src/fdopendir-with-access.c
+++ b/tests/c/src/fdopendir-with-access.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
   int expected[2] = {0};
   ino_t inodes[2];
 
-  dfd = open("fs-tests.dir/fopendir.dir", O_RDONLY | O_DIRECTORY);
+  dfd = open("fopendir.dir", O_RDONLY | O_DIRECTORY);
   assert(dfd != -1);
 
   d = fdopendir((dfd));

--- a/tests/c/src/fdopendir-with-access.json
+++ b/tests/c/src/fdopendir-with-access.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/c/src/fopen-with-access.c
+++ b/tests/c/src/fopen-with-access.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 int main() {
-  FILE *file = fopen("fs-tests.dir/file", "r");
+  FILE *file = fopen("file", "r");
 
   assert(file != NULL);
 

--- a/tests/c/src/fopen-with-access.json
+++ b/tests/c/src/fopen-with-access.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/c/src/lseek.c
+++ b/tests/c/src/lseek.c
@@ -11,7 +11,7 @@ int main() {
   FILE *file;
   size_t size;
 
-  file = fopen("fs-tests.dir/lseek.txt", "r");
+  file = fopen("lseek.txt", "r");
   assert(file != NULL);
 
   fd = fileno(file);

--- a/tests/c/src/lseek.json
+++ b/tests/c/src/lseek.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/c/src/pread-with-access.c
+++ b/tests/c/src/pread-with-access.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
   const int expected_len = strlen(expected);
   char read_buf[16];
 
-  fd = open("fs-tests.dir/pread.txt", O_RDONLY);
+  fd = open("pread.txt", O_RDONLY);
   assert(fd > 0);
 
   do {

--- a/tests/c/src/pread-with-access.json
+++ b/tests/c/src/pread-with-access.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/c/src/pwrite-with-access.c
+++ b/tests/c/src/pwrite-with-access.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
   int written;
   int fd;
   struct stat buf;
-  char *test_file = "fs-tests.dir/writeable/test_pwrite_pread.txt.cleanup";
+  char *test_file = "writeable/test_pwrite_pread.txt.cleanup";
   char *full_content = "very long text";
   int full_content_len = strlen(full_content);
   const char *sub_content = "test";

--- a/tests/c/src/pwrite-with-access.json
+++ b/tests/c/src/pwrite-with-access.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/c/src/pwrite-with-append.c
+++ b/tests/c/src/pwrite-with-append.c
@@ -8,7 +8,7 @@ int main() {
   int fd;
   size_t size;
 
-  fd = open("fs-tests.dir/pwrite.cleanup",
+  fd = open("pwrite.cleanup",
             O_CREAT | O_TRUNC | O_WRONLY | O_APPEND);
   assert(fd != -1);
 

--- a/tests/c/src/pwrite-with-append.c
+++ b/tests/c/src/pwrite-with-append.c
@@ -8,8 +8,7 @@ int main() {
   int fd;
   size_t size;
 
-  fd = open("pwrite.cleanup",
-            O_CREAT | O_TRUNC | O_WRONLY | O_APPEND);
+  fd = open("pwrite.cleanup", O_CREAT | O_TRUNC | O_WRONLY | O_APPEND);
   assert(fd != -1);
 
   size = write(fd, buf, 2);

--- a/tests/c/src/pwrite-with-append.json
+++ b/tests/c/src/pwrite-with-append.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/c/src/stat-dev-ino.c
+++ b/tests/c/src/stat-dev-ino.c
@@ -7,10 +7,10 @@
 #include <unistd.h>
 
 int main() {
-  int a = open("fs-tests.dir/file", O_RDONLY);
+  int a = open("file", O_RDONLY);
   assert(a != -1);
 
-  int b = open("fs-tests.dir/lseek.txt", O_RDONLY);
+  int b = open("lseek.txt", O_RDONLY);
   assert(b != -1);
 
   struct stat a_stat;

--- a/tests/c/src/stat-dev-ino.json
+++ b/tests/c/src/stat-dev-ino.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip1/src/bin/close_preopen.json
+++ b/tests/rust/wasm32-wasip1/src/bin/close_preopen.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/close_preopen.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/close_preopen.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, open_scratch_directory};
+use wasi_tests::{assert_errno, root_directory};
 
 unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
     let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
@@ -25,17 +25,7 @@ unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/dangling_fd.json
+++ b/tests/rust/wasm32-wasip1/src/bin/dangling_fd.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/dangling_fd.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/dangling_fd.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{TESTCONFIG, open_scratch_directory};
+use wasi_tests::{TESTCONFIG, root_directory};
 
 unsafe fn test_dangling_fd(dir_fd: wasi::Fd) {
     if TESTCONFIG.support_dangling_filesystem() {
@@ -35,17 +35,7 @@ unsafe fn test_dangling_fd(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/dangling_symlink.json
+++ b/tests/rust/wasm32-wasip1/src/bin/dangling_symlink.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/dangling_symlink.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/dangling_symlink.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{TESTCONFIG, assert_errno, open_scratch_directory};
+use wasi_tests::{TESTCONFIG, assert_errno, root_directory};
 
 unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
     if TESTCONFIG.support_dangling_filesystem() {
@@ -30,17 +30,7 @@ unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/dir_fd_op_failures.json
+++ b/tests/rust/wasm32-wasip1/src/bin/dir_fd_op_failures.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/dir_fd_op_failures.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/dir_fd_op_failures.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, open_scratch_directory};
+use wasi_tests::{assert_errno, root_directory};
 
 unsafe fn test_fd_dir_ops(dir_fd: wasi::Fd) {
     let stat = wasi::fd_filestat_get(dir_fd).expect("failed to fdstat");
@@ -121,17 +121,7 @@ unsafe fn test_fd_dir_ops(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/directory_seek.json
+++ b/tests/rust/wasm32-wasip1/src/bin/directory_seek.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/directory_seek.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/directory_seek.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, open_scratch_directory};
+use wasi_tests::{assert_errno, root_directory};
 
 unsafe fn test_directory_seek(dir_fd: wasi::Fd) {
     const DIR_NAME: &str = "directory_seek_dir.cleanup";
@@ -49,17 +49,7 @@ unsafe fn test_directory_seek(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/fd_advise.json
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_advise.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/fd_advise.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_advise.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::open_scratch_directory;
+use wasi_tests::root_directory;
 
 unsafe fn test_fd_advise(dir_fd: wasi::Fd) {
     const FILE_NAME: &str = "fd_advise_file.cleanup";
@@ -55,17 +55,7 @@ unsafe fn test_fd_advise(dir_fd: wasi::Fd) {
     wasi::path_unlink_file(dir_fd, FILE_NAME).expect("failed to unlink");
 }
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.json
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
@@ -1,7 +1,6 @@
 use std::{env, process};
 use wasi_tests::{
-    assert_errno, create_tmp_dir, drop_rights, fd_get_rights, root_directory,
-    supports_rights,
+    assert_errno, create_tmp_dir, drop_rights, fd_get_rights, root_directory, supports_rights,
 };
 
 const TEST_FILENAME: &'static str = "file.cleanup";

--- a/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_fdstat_set_rights.rs
@@ -1,6 +1,6 @@
 use std::{env, process};
 use wasi_tests::{
-    assert_errno, create_tmp_dir, drop_rights, fd_get_rights, open_scratch_directory,
+    assert_errno, create_tmp_dir, drop_rights, fd_get_rights, root_directory,
     supports_rights,
 };
 
@@ -99,17 +99,7 @@ unsafe fn test_fd_fdstat_set_rights(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/fd_filestat_set.json
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_filestat_set.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/fd_filestat_set.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_filestat_set.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::open_scratch_directory;
+use wasi_tests::root_directory;
 
 unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
     const FILE_NAME: &str = "fd_filestat_set_file.cleanup";
@@ -51,17 +51,7 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
     wasi::path_unlink_file(dir_fd, FILE_NAME).expect("failed to remove dir");
 }
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/fd_flags_set.json
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_flags_set.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/fd_flags_set.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_flags_set.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::open_scratch_directory;
+use wasi_tests::root_directory;
 
 unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
     const FILE_NAME: &str = "fd_flags_set_file.cleanup";
@@ -141,16 +141,7 @@ unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/fd_readdir.json
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_readdir.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/fd_readdir.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fd_readdir.rs
@@ -1,5 +1,5 @@
 use std::{env, mem, process, slice, str};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 const BUF_LEN: usize = 256;
 
@@ -190,17 +190,7 @@ unsafe fn test_fd_readdir_lots(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/file_allocate.json
+++ b/tests/rust/wasm32-wasip1/src/bin/file_allocate.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/file_allocate.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/file_allocate.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -49,17 +49,7 @@ unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/file_pread_pwrite.json
+++ b/tests/rust/wasm32-wasip1/src/bin/file_pread_pwrite.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/file_pread_pwrite.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/file_pread_pwrite.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -129,17 +129,7 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/file_seek_tell.json
+++ b/tests/rust/wasm32-wasip1/src/bin/file_seek_tell.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/file_seek_tell.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/file_seek_tell.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_file_seek_tell(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -80,17 +80,7 @@ unsafe fn test_file_seek_tell(dir_fd: wasi::Fd) {
     wasi::path_unlink_file(dir_fd, "file").expect("deleting a file");
 }
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/file_truncation.json
+++ b/tests/rust/wasm32-wasip1/src/bin/file_truncation.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/file_truncation.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/file_truncation.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
     const FILENAME: &str = "test.txt";
@@ -62,17 +62,7 @@ unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/file_unbuffered_write.json
+++ b/tests/rust/wasm32-wasip1/src/bin/file_unbuffered_write.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/file_unbuffered_write.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/file_unbuffered_write.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn test_file_unbuffered_write(dir_fd: wasi::Fd) {
     // Create and open file for reading
@@ -51,17 +51,7 @@ unsafe fn test_file_unbuffered_write(dir_fd: wasi::Fd) {
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.json
+++ b/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/fstflags_validate.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::open_scratch_directory;
+use wasi_tests::root_directory;
 
 unsafe fn test_fstflags_validate(dir_fd: wasi::Fd) {
     const FILE_NAME: &str = "fstflags_validate.cleanup";
@@ -40,17 +40,7 @@ unsafe fn test_fstflags_validate(dir_fd: wasi::Fd) {
     wasi::fd_close(file_fd).expect("failed to close fd");
 }
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/interesting_paths.json
+++ b/tests/rust/wasm32-wasip1/src/bin/interesting_paths.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/interesting_paths.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/interesting_paths.rs
@@ -1,8 +1,8 @@
 use std::{env, process};
 use wasi::path_create_directory;
-use wasi_tests::{assert_errno, create_file, open_scratch_directory};
+use wasi_tests::{assert_errno, create_file, root_directory};
 
-unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
+unsafe fn test_interesting_paths(dir_fd: wasi::Fd) {
     // Create a directory in the scratch directory.
     wasi::path_create_directory(dir_fd, "dir").expect("creating dir");
 
@@ -81,9 +81,9 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     wasi::fd_close(file_fd).expect("closing a file");
 
     // Now open it with a path containing too many ".."s.
-    let bad_path = format!("dir/nested/../../../{}/dir/nested/file", arg);
+    let bad_path = "dir/nested/../../../dir/nested/file";
     assert_errno!(
-        wasi::path_open(dir_fd, 0, &bad_path, 0, 0, 0, 0)
+        wasi::path_open(dir_fd, 0, bad_path, 0, 0, 0, 0)
             .expect_err("opening a file with too many \"..\"s in the path should fail"),
         wasi::ERRNO_PERM,
         wasi::ERRNO_NOTCAPABLE
@@ -121,17 +121,7 @@ unsafe fn create_tmp_dir(dir_fd: wasi::Fd, name: &str) -> wasi::Fd {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);
@@ -146,7 +136,7 @@ fn main() {
     }
 
     // Run the tests.
-    unsafe { test_interesting_paths(dir_fd, &arg) }
+    unsafe { test_interesting_paths(dir_fd) }
 
     unsafe {
         wasi::fd_close(dir_fd).unwrap();

--- a/tests/rust/wasm32-wasip1/src/bin/isatty.json
+++ b/tests/rust/wasm32-wasip1/src/bin/isatty.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/isatty.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/isatty.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn test_isatty(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory and test if it's a tty.
@@ -19,17 +19,7 @@ unsafe fn test_isatty(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/nofollow_errors.json
+++ b/tests/rust/wasm32-wasip1/src/bin/nofollow_errors.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/nofollow_errors.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/nofollow_errors.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
     // Create a directory for the symlink to point to.
@@ -87,17 +87,7 @@ unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/overwrite_preopen.json
+++ b/tests/rust/wasm32-wasip1/src/bin/overwrite_preopen.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/overwrite_preopen.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/overwrite_preopen.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_overwrite_preopen(dir_fd: wasi::Fd) {
     let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
@@ -27,17 +27,7 @@ unsafe fn test_overwrite_preopen(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_exists.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_exists.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_exists.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_exists.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_file, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_file, create_tmp_dir, root_directory};
 
 unsafe fn test_path_exists(dir_fd: wasi::Fd) {
     // Create a temporary directory
@@ -55,17 +55,7 @@ unsafe fn test_path_exists(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_filestat.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_filestat.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_filestat.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_filestat.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
     let mut fdstat = wasi::fd_fdstat_get(dir_fd).expect("fd_fdstat_get");
@@ -98,17 +98,7 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_link.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_link.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_link.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_link.rs
@@ -1,6 +1,6 @@
 use std::{env, process};
 use wasi_tests::{
-    TESTCONFIG, assert_errno, create_file, create_tmp_dir, open_scratch_directory, supports_rights,
+    TESTCONFIG, assert_errno, create_file, create_tmp_dir, root_directory, supports_rights,
 };
 
 const TEST_RIGHTS: wasi::Rights = wasi::RIGHTS_FD_READ
@@ -202,17 +202,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_create_existing.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_create_existing.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_create_existing.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_create_existing.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_file, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_file, create_tmp_dir, root_directory};
 
 unsafe fn test_path_open_create_existing(dir_fd: wasi::Fd) {
     create_file(dir_fd, "file");
@@ -20,17 +20,7 @@ unsafe fn test_path_open_create_existing(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_dirfd_not_dir.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_dirfd_not_dir.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_dirfd_not_dir.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_dirfd_not_dir.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_dirfd_not_dir(dir_fd: wasi::Fd) {
     // Open a file.
@@ -17,17 +17,7 @@ unsafe fn test_dirfd_not_dir(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_missing.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_missing.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_missing.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_missing.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_path_open_missing(dir_fd: wasi::Fd) {
     assert_errno!(
@@ -13,17 +13,7 @@ unsafe fn test_path_open_missing(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_nonblock.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_nonblock.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_nonblock.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_nonblock.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::open_scratch_directory;
+use wasi_tests::root_directory;
 
 unsafe fn try_path_open(dir_fd: wasi::Fd) {
     let _fd =
@@ -7,17 +7,7 @@ unsafe fn try_path_open(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_preopen.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_preopen.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_preopen.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_preopen.rs
@@ -1,5 +1,3 @@
-use std::{env, process};
-
 unsafe fn find_first_preopened_fd(path: &str) -> Result<wasi::Fd, String> {
     let max_fd = (1 << 31) - 1;
 
@@ -125,17 +123,7 @@ unsafe fn path_open_preopen(preopened_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    let preopened_fd = unsafe { find_first_preopened_fd(arg.as_str()).unwrap() };
+    let preopened_fd = unsafe { find_first_preopened_fd("/").unwrap() };
 
     // Run the tests.
     unsafe { path_open_preopen(preopened_fd) }

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_read_write.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_read_write.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_open_read_write.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_open_read_write.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_file, open_scratch_directory};
+use wasi_tests::{assert_errno, create_file, root_directory};
 
 const TEST_FILENAME: &'static str = "file.cleanup";
 
@@ -120,17 +120,7 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_rename.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_rename.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_rename.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_rename.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{TESTCONFIG, assert_errno, create_file, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{TESTCONFIG, assert_errno, create_file, create_tmp_dir, root_directory};
 
 unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     // First, try renaming a dir to nonexistent path
@@ -152,17 +152,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_rename_dir_trailing_slashes.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_rename_dir_trailing_slashes.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_rename_dir_trailing_slashes.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_rename_dir_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn test_path_rename_trailing_slashes(dir_fd: wasi::Fd) {
     // Test renaming a directory with a trailing slash in the name.
@@ -16,17 +16,7 @@ unsafe fn test_path_rename_trailing_slashes(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/path_symlink_trailing_slashes.json
+++ b/tests/rust/wasm32-wasip1/src/bin/path_symlink_trailing_slashes.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/path_symlink_trailing_slashes.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/path_symlink_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{TESTCONFIG, assert_errno, create_file, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{TESTCONFIG, assert_errno, create_file, create_tmp_dir, root_directory};
 
 unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
     if TESTCONFIG.support_dangling_filesystem() {
@@ -61,17 +61,7 @@ unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/readlink.json
+++ b/tests/rust/wasm32-wasip1/src/bin/readlink.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/readlink.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/readlink.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_file, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_file, create_tmp_dir, root_directory};
 
 unsafe fn test_readlink(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -35,17 +35,7 @@ unsafe fn test_readlink(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/remove_directory_trailing_slashes.json
+++ b/tests/rust/wasm32-wasip1/src/bin/remove_directory_trailing_slashes.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/remove_directory_trailing_slashes.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/remove_directory_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_file, open_scratch_directory};
+use wasi_tests::{assert_errno, create_file, root_directory};
 
 const TEST_FILENAME: &'static str = "file.cleanup";
 const TEST_DIRNAME: &'static str = "dir.cleanup";
@@ -45,17 +45,7 @@ unsafe fn test_remove_directory_trailing_slashes(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/remove_nonempty_directory.json
+++ b/tests/rust/wasm32-wasip1/src/bin/remove_nonempty_directory.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/remove_nonempty_directory.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/remove_nonempty_directory.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_remove_nonempty_directory(dir_fd: wasi::Fd) {
     // Create a directory in the scratch directory.
@@ -22,17 +22,7 @@ unsafe fn test_remove_nonempty_directory(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/renumber.json
+++ b/tests/rust/wasm32-wasip1/src/bin/renumber.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/renumber.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/renumber.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_renumber(dir_fd: wasi::Fd) {
     let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
@@ -86,17 +86,7 @@ unsafe fn test_renumber(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/stdio.json
+++ b/tests/rust/wasm32-wasip1/src/bin/stdio.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/stdio.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/stdio.rs
@@ -1,6 +1,6 @@
 use std::{env, process};
 
-use wasi_tests::{STDERR_FD, STDIN_FD, STDOUT_FD, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{STDERR_FD, STDIN_FD, STDOUT_FD, create_tmp_dir, root_directory};
 
 const TEST_FILENAME: &'static str = "file.cleanup";
 
@@ -21,16 +21,7 @@ unsafe fn test_stdio(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/symlink_create.json
+++ b/tests/rust/wasm32-wasip1/src/bin/symlink_create.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/symlink_create.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/symlink_create.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn create_symlink_to_file(dir_fd: wasi::Fd) {
     // Create a directory for the symlink to point to.
@@ -68,17 +68,7 @@ unsafe fn create_symlink_to_root(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/symlink_filestat.json
+++ b/tests/rust/wasm32-wasip1/src/bin/symlink_filestat.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/symlink_filestat.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/symlink_filestat.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{create_tmp_dir, open_scratch_directory};
+use wasi_tests::{create_tmp_dir, root_directory};
 
 unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
     let fdstat = wasi::fd_fdstat_get(dir_fd).expect("fd_fdstat_get");
@@ -85,17 +85,7 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/symlink_loop.json
+++ b/tests/rust/wasm32-wasip1/src/bin/symlink_loop.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/symlink_loop.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/symlink_loop.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{TESTCONFIG, assert_errno, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{TESTCONFIG, assert_errno, create_tmp_dir, root_directory};
 
 unsafe fn test_symlink_loop(dir_fd: wasi::Fd) {
     if TESTCONFIG.support_dangling_filesystem()
@@ -18,17 +18,7 @@ unsafe fn test_symlink_loop(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/truncation_rights.json
+++ b/tests/rust/wasm32-wasip1/src/bin/truncation_rights.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/truncation_rights.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/truncation_rights.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_file, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_file, create_tmp_dir, root_directory};
 
 unsafe fn test_truncation_rights(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -78,17 +78,7 @@ unsafe fn test_truncation_rights(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/bin/unlink_file_trailing_slashes.json
+++ b/tests/rust/wasm32-wasip1/src/bin/unlink_file_trailing_slashes.json
@@ -1,4 +1,4 @@
 {
-    "dirs": ["fs-tests.dir"],
-    "args": ["fs-tests.dir"]
+    "root": "fs-tests.dir",
+    "args": []
 }

--- a/tests/rust/wasm32-wasip1/src/bin/unlink_file_trailing_slashes.rs
+++ b/tests/rust/wasm32-wasip1/src/bin/unlink_file_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_file, create_tmp_dir, open_scratch_directory};
+use wasi_tests::{assert_errno, create_file, create_tmp_dir, root_directory};
 
 unsafe fn test_unlink_file_trailing_slashes(dir_fd: wasi::Fd) {
     // Create a directory in the scratch directory.
@@ -43,17 +43,7 @@ unsafe fn test_unlink_file_trailing_slashes(dir_fd: wasi::Fd) {
 }
 
 fn main() {
-    let mut args = env::args();
-    let prog = args.next().unwrap();
-    let arg = if let Some(arg) = args.next() {
-        arg
-    } else {
-        eprintln!("usage: {} <scratch directory>", prog);
-        process::exit(1);
-    };
-
-    // Open scratch directory
-    let base_dir_fd = match open_scratch_directory(&arg) {
+    let base_dir_fd = match root_directory() {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/tests/rust/wasm32-wasip1/src/lib.rs
+++ b/tests/rust/wasm32-wasip1/src/lib.rs
@@ -58,7 +58,7 @@ pub unsafe fn create_tmp_dir(dir_fd: wasi::Fd, name: &str) -> wasi::Fd {
 
 /// Opens a fresh file descriptor for `path` where `path` should be a preopened
 /// directory.
-pub fn open_scratch_directory(path: &str) -> Result<wasi::Fd, String> {
+pub fn root_directory() -> Result<wasi::Fd, String> {
     unsafe {
         for i in 3.. {
             let stat = match wasi::fd_prestat_get(i) {
@@ -73,7 +73,7 @@ pub fn open_scratch_directory(path: &str) -> Result<wasi::Fd, String> {
                 continue;
             }
             dst.set_len(stat.u.dir.pr_name_len);
-            if dst == path.as_bytes() {
+            if dst == b"/" {
                 let (base, inherit) = fd_get_rights(i);
                 return Ok(
                     wasi::path_open(i, 0, ".", wasi::OFLAGS_DIRECTORY, base, inherit, 0)

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-advise.rs
@@ -66,11 +66,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_advise(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-dotdot.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-dotdot.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-flags-and-type.rs
@@ -154,11 +154,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_flags_and_type(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-hard-links.rs
@@ -78,11 +78,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_hard_links(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-io.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-io.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-io.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-io.rs
@@ -213,11 +213,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_io(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-is-same-object.rs
@@ -93,11 +93,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_is_same_object(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-metadata-hash.rs
@@ -186,11 +186,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_metadata_hash(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-mkdir-rmdir.rs
@@ -41,30 +41,24 @@ async fn test_mkdir_rmdir(dir: &Descriptor) {
         );
     }
     assert_eq!(mkdir("/").await, Err(ErrorCode::NotPermitted));
-    assert_eq!(
-        mkdir("../fs-tests.dir/q.cleanup").await,
-        Err(ErrorCode::NotPermitted)
-    );
+    assert_eq!(mkdir("../q.cleanup").await, Err(ErrorCode::NotPermitted));
     if has_symlink {
         assert_eq!(
-            mkdir("parent.cleanup/fs-tests.dir/q.cleanup").await,
+            mkdir("parent.cleanup/q.cleanup").await,
             Err(ErrorCode::NotPermitted)
         );
     }
     assert_eq!(mkdir("a.txt").await, Err(ErrorCode::Exist));
     mkdir("q.cleanup").await.unwrap();
-    assert_eq!(
-        rmdir("../fs-tests.dir/q.cleanup").await,
-        Err(ErrorCode::NotPermitted)
-    );
+    assert_eq!(rmdir("../q.cleanup").await, Err(ErrorCode::NotPermitted));
     if has_symlink {
         assert_eq!(
-            rmdir("parent.cleanup/fs-tests.dir/q.cleanup").await,
+            rmdir("parent.cleanup/q.cleanup").await,
             Err(ErrorCode::NotPermitted)
         );
     }
     assert_eq!(
-        rmdir("q.cleanup/../../fs-tests.dir/q.cleanup").await,
+        rmdir("q.cleanup/../../q.cleanup").await,
         Err(ErrorCode::NotPermitted)
     );
     rmdir("q.cleanup").await.unwrap();
@@ -98,10 +92,7 @@ async fn test_mkdir_rmdir(dir: &Descriptor) {
     if has_symlink {
         // FIXME: https://github.com/bytecodealliance/wasmtime/issues/12178
         // assert_eq!(rmdir("parent.cleanup").await, Err(ErrorCode::NotDirectory));
-        assert_eq!(
-            rmdir("parent.cleanup/fs-tests.dir").await,
-            Err(ErrorCode::NotPermitted)
-        );
+        assert_eq!(rmdir("parent.cleanup/").await, Err(ErrorCode::NotPermitted));
     }
 
     mkdir("child.cleanup").await.unwrap();
@@ -154,11 +145,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_mkdir_rmdir(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-open-errors.rs
@@ -60,11 +60,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_open_errors(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-read-directory.rs
@@ -55,11 +55,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_read_directory(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-rename.rs
@@ -102,11 +102,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_rename(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-set-size.rs
@@ -119,11 +119,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_set_size(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-stat.rs
@@ -244,11 +244,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_stat(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.json
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.json
@@ -1,3 +1,3 @@
 {
-    "dirs": ["fs-tests.dir"]
+    "root": "fs-tests.dir"
 }

--- a/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/filesystem-unlink-errors.rs
@@ -36,7 +36,7 @@ async fn test_unlink_errors(dir: &Descriptor) {
     assert_eq!(rm("").await, Err(ErrorCode::NoEntry));
     assert!(is_acceptable_unlink_dir_result(rm(".").await));
     assert!(is_acceptable_unlink_dir_result(rm("..").await));
-    assert!(is_acceptable_unlink_dir_result(rm("../fs-tests.dir").await));
+    assert!(is_acceptable_unlink_dir_result(rm("../").await));
     assert!(is_acceptable_unlink_dir_result(rm("/").await));
     assert_eq!(rm("/etc/passwd").await, Err(ErrorCode::NotPermitted));
     assert_eq!(rm("/etc/passwd").await, Err(ErrorCode::NotPermitted));
@@ -54,11 +54,11 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         match &wasi::filesystem::preopens::get_directories()[..] {
-            [(dir, dirname)] if dirname == "fs-tests.dir" => {
+            [(dir, _)] => {
                 test_unlink_errors(dir).await;
             }
             [..] => {
-                eprintln!("usage: run with one open dir named 'fs-tests.dir'");
+                eprintln!("usage: run with one open dir");
                 process::exit(1)
             }
         };


### PR DESCRIPTION
This commit is a refactor of all filesystem tests and their configuration to have only a single root directory instead of a list of preopened directories. The purpose of this change is to start moving in the direction of "there's just a root filesystem for WASI guests" as opposed to guests having a set of preopened directories they get to choose from. Tests are refactored in how they access preopened directories and search around for them. The JSON configuration of `dirs` is now just `root` and is optionally specified like before. Additionally passing the name of the first preopen as an argument is now no longer necessary so that's removed too.