### PR TITLE
chore: bump wasi-sdk and wasm-tools

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -19,7 +19,7 @@
 
 [external_cell_wasmono]
   git_origin = https://github.com/andreiltd/wasmono.git
-  commit_hash = 040f838f488966c94d74c5aa3db61f296f98ddb1
+  commit_hash = d7c49b331295c6bc04711e2f735a425c21b0217f
 
 [parser]
   target_platform_detector_spec = target:root//...->prelude//platforms:default \

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -44,7 +44,7 @@ alias(name = "node_dist_shared", actual = ":node_dist", visibility = ["toolchain
 toolchain_alias(name = "asc", actual = "//typescript:asc", visibility = ["PUBLIC"])
 
 # Component-model tooling used to lift Rust WASI P3 core modules into components.
-download_wasm_tools(name = "wasm_tools_dist", version = "1.245.1")
+download_wasm_tools(name = "wasm_tools_dist", version = "1.252.0")
 wasm_tools_toolchain(name = "wasm_tools", distribution = ":wasm_tools_dist", visibility = ["PUBLIC"])
 
 # Test execution toolchains required by Buck's test command.

--- a/toolchains/cxx/BUCK
+++ b/toolchains/cxx/BUCK
@@ -11,7 +11,7 @@ load(
 )
 load(":defs.bzl", "clang_format")
 
-download_wasi_sdk(name = "wasi_sdk", version = "27.0")
+download_wasi_sdk(name = "wasi_sdk", version = "33.0")
 
 cxx_wasi_toolchain(
     name = "cxx_wasi_p1",


### PR DESCRIPTION
- wasi-sdk 27 -> 33
- wasm-tools 1.245.1 -> 1.252.0