### PR TITLE
p3(http): Expand tests for http roundtrip

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,8 +6,10 @@ pkgs.mkShell {
     python3
     python3Packages.pip
     python3Packages.virtualenv
+    buck2
+    dotslash
   ];
-  
+
   shellHook = ''
     # Create and activate virtual environment
     if [ ! -d .venv ]; then

--- a/test-runner/tests/test_test_case.py
+++ b/test-runner/tests/test_test_case.py
@@ -202,6 +202,33 @@ def test_request_from_config() -> None:
     assert req.method == "POST"
     assert req.path == "/"
     assert req.response == Response(status=200, headers={}, body="hey")
+    assert req.headers == {}
+    assert req.body == ""
+
+
+def test_request_from_config_with_body_and_headers() -> None:
+    req = Request.from_config({
+        "method": "POST",
+        "path": "/echo",
+        "headers": {"x-echo": "ping"},
+        "body": "hello",
+        "response": {"status": 200, "body": "hello"},
+    })
+    assert req.method == "POST"
+    assert req.path == "/echo"
+    assert req.headers == {"x-echo": "ping"}
+    assert req.body == "hello"
+    assert req.response == Response(status=200, headers={}, body="hello")
+
+
+def test_request_from_config_rejects_non_dict_headers() -> None:
+    with pytest.raises(ValueError):
+        Request.from_config({"headers": "not-a-dict", "response": {}})
+
+
+def test_request_from_config_rejects_non_str_body() -> None:
+    with pytest.raises(ValueError):
+        Request.from_config({"body": 123, "response": {}})
 
 
 def test_kill_from_config_with_signal() -> None:

--- a/test-runner/wasi_test_runner/test_case.py
+++ b/test-runner/wasi_test_runner/test_case.py
@@ -236,20 +236,33 @@ class Request(NamedTuple):
     method: str
     path: str
     response: Response
+    headers: Dict[str, str] = {}
+    body: str = ""
 
     @classmethod
     def from_config(cls: Type[Req], config: Dict[str, Any]) -> Req:
         method = config.get("method", "GET")
         path = config.get("path", "/")
         response = config.get("response", {})
+        headers = config.get("headers", {})
+        body = config.get("body", "")
 
         if not isinstance(method, str):
             raise ValueError("Request method should be a str")
         if not isinstance(path, str):
             raise ValueError("Request path should be a str")
+        if not isinstance(headers, dict):
+            raise ValueError("Request headers should be a dict")
+        for k, v in headers.items():
+            if not isinstance(k, str):
+                raise ValueError("Request header name should be a str")
+            if not isinstance(v, str):
+                raise ValueError("Request header value should be a str")
+        if not isinstance(body, str):
+            raise ValueError("Request body should be a str")
         response = Response.from_config(response)
 
-        return cls(method, path, response)
+        return cls(method, path, response, headers, body)
 
 
 K = TypeVar("K", bound="Kill")

--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -227,7 +227,13 @@ class TestCaseRunner(TestCaseRunnerBase):
             return
         url = join_http_url(http_server, req.path)
         try:
-            response = requests.request(req.method, url, timeout=5)
+            response = requests.request(
+                req.method,
+                url,
+                headers=req.headers or None,
+                data=req.body.encode("utf-8") if req.body else None,
+                timeout=5,
+            )
         except requests.exceptions.Timeout:
             self.fail_unexpected(f"{req}: Timeout waiting for response")
             return

--- a/tests/rust/wasm32-wasip3/BUCK
+++ b/tests/rust/wasm32-wasip3/BUCK
@@ -60,6 +60,7 @@ _RUST_P3_TESTS = [
     rust_p3_test("http-request", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("http-response", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("http-service", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
+    rust_p3_test("http-service-echo", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("monotonic-clock", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("multi-clock-wait", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("random", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),

--- a/tests/rust/wasm32-wasip3/src/bin/http-service-echo.json
+++ b/tests/rust/wasm32-wasip3/src/bin/http-service-echo.json
@@ -1,0 +1,32 @@
+{
+  "proposals": ["http"],
+  "world": "wasi:http/service",
+  "operations": [
+    { "type": "run" },
+    { "type": "request",
+      "method": "POST",
+      "path": "/echo",
+      "body": "hello, echo",
+      "response": { "status": 200,
+                    "headers": { "content-type": "application/octet-stream" },
+                    "body": "hello, echo" } },
+    { "type": "request",
+      "method": "POST",
+      "path": "/echo",
+      "body": "",
+      "response": { "status": 200,
+                    "body": "" } },
+    { "type": "request",
+      "method": "GET",
+      "path": "/reflect-header",
+      "headers": { "x-echo": "ping" },
+      "response": { "status": 200,
+                    "headers": { "x-echoed": "ping" } } },
+    { "type": "request",
+      "method": "GET",
+      "path": "/whatever",
+      "response": { "status": 404 } },
+    { "type": "kill", "signal": "SIGINT" },
+    { "type": "wait" }
+  ]
+}

--- a/tests/rust/wasm32-wasip3/src/bin/http-service-echo.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/http-service-echo.rs
@@ -1,0 +1,62 @@
+use test_wasm32_wasip3::http::{export, exports::wasi::http::handler::Guest};
+use test_wasm32_wasip3::http::{
+    wasi::http::types::{ErrorCode, Fields, Method, Request, Response, StatusCode},
+    wit_future, wit_stream,
+};
+
+struct Component;
+export!(Component);
+
+impl Guest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let method = request.get_method();
+        let path = request.get_path_with_query();
+
+        let req_headers = request.get_headers();
+
+        let (_, result_rx) = wit_future::new(|| Ok(()));
+        let (body_rx, trailers) = Request::consume_body(request, result_rx);
+        let body = body_rx.collect().await;
+        let _ = trailers.await;
+
+        let headers = Fields::new();
+        let (status, payload): (StatusCode, Option<Vec<u8>>) = match (method, path.as_deref()) {
+            (Method::Post, Some("/echo")) => {
+                headers
+                    .append("content-type", b"application/octet-stream")
+                    .unwrap();
+                (200, Some(body))
+            }
+            (Method::Get, Some("/reflect-header")) => {
+                if let Some(value) = req_headers.get("x-echo").first() {
+                    headers.append("x-echoed", value).unwrap();
+                }
+                (200, None)
+            }
+            _ => (404, None),
+        };
+
+        let response_body = payload.map(|bytes| {
+            headers
+                .append("content-length", &bytes.len().to_string().into_bytes())
+                .unwrap();
+            let (mut body_tx, body_rx) = wit_stream::new();
+            wit_bindgen::spawn_local(async move {
+                let remaining = body_tx.write_all(bytes).await;
+                assert!(remaining.is_empty());
+                drop(body_tx);
+            });
+            body_rx
+        });
+
+        let (trailers_tx, trailers_rx) = wit_future::new(|| Ok(None));
+        drop(trailers_tx);
+        let (response, _sent) = Response::new(headers, response_body, trailers_rx);
+        response.set_status_code(status).unwrap();
+        Ok(response)
+    }
+}
+
+fn main() {
+    unreachable!("main is a stub");
+}


### PR DESCRIPTION
This patch introduces `http-service-echo.rs` which is an enhancement to the existing `http-service.rs` test. Particularly, it tests:

* Reading a non-empty inbound body
* Reading inbound headers
* Teaches the python runner and configuration how to send payloads in http requests.