### PR TITLE
p3(http): Assert request get-{authority,scheme}

### DIFF
--- a/expectations/wasmtime/linux.toml
+++ b/expectations/wasmtime/linux.toml
@@ -2,3 +2,10 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
+
+# Inbound request scheme / authority are not always set, see:
+# - https://github.com/WebAssembly/WASI/issues/788
+# - https://github.com/bytecodealliance/wasmtime/issues/11571
+[[suite.test]]
+name = "http-service-uri"
+expected = "fail"

--- a/expectations/wasmtime/macos.toml
+++ b/expectations/wasmtime/macos.toml
@@ -6,3 +6,10 @@ name = "WASI Rust tests [wasm32-wasip3]"
 [[suite.test]]
 name = "filesystem-mkdir-rmdir"
 expected = "fail"
+
+# Inbound request scheme / authority are not always set, see:
+# - https://github.com/WebAssembly/WASI/issues/788
+# - https://github.com/bytecodealliance/wasmtime/issues/11571
+[[suite.test]]
+name = "http-service-uri"
+expected = "fail"

--- a/expectations/wasmtime/windows.toml
+++ b/expectations/wasmtime/windows.toml
@@ -2,3 +2,10 @@ version = 1
 
 [[suite]]
 name = "WASI Rust tests [wasm32-wasip3]"
+
+# Inbound request scheme / authority are not always set, see:
+# - https://github.com/WebAssembly/WASI/issues/788
+# - https://github.com/bytecodealliance/wasmtime/issues/11571
+[[suite.test]]
+name = "http-service-uri"
+expected = "fail"

--- a/tests/rust/wasm32-wasip3/BUCK
+++ b/tests/rust/wasm32-wasip3/BUCK
@@ -61,6 +61,7 @@ _RUST_P3_TESTS = [
     rust_p3_test("http-response", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("http-service", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("http-service-echo", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
+    rust_p3_test("http-service-uri", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("monotonic-clock", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("multi-clock-wait", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("random", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),

--- a/tests/rust/wasm32-wasip3/src/bin/http-service-uri.json
+++ b/tests/rust/wasm32-wasip3/src/bin/http-service-uri.json
@@ -1,0 +1,13 @@
+{
+  "proposals": ["http"],
+  "world": "wasi:http/service",
+  "operations": [
+    { "type": "run" },
+    { "type": "request",
+      "method": "GET",
+      "path": "/whoami",
+      "response": { "status": 200 } },
+    { "type": "kill", "signal": "SIGINT" },
+    { "type": "wait" }
+  ]
+}

--- a/tests/rust/wasm32-wasip3/src/bin/http-service-uri.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/http-service-uri.rs
@@ -1,0 +1,33 @@
+use test_wasm32_wasip3::http::{export, exports::wasi::http::handler::Guest};
+use test_wasm32_wasip3::http::{
+    wasi::http::types::{ErrorCode, Fields, Request, Response},
+    wit_future,
+};
+
+struct Component;
+export!(Component);
+
+impl Guest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        assert!(request.get_scheme().is_some(), "expected scheme to be set");
+        assert!(
+            request.get_authority().is_some(),
+            "expected authority to be set"
+        );
+
+        let (_, result_rx) = wit_future::new(|| Ok(()));
+        let (body_rx, trailers) = Request::consume_body(request, result_rx);
+        let _ = body_rx.collect().await;
+        let _ = trailers.await;
+
+        let (trailers_tx, trailers_rx) = wit_future::new(|| Ok(None));
+        drop(trailers_tx);
+        let (response, _sent) = Response::new(Fields::new(), None, trailers_rx);
+        response.set_status_code(200).unwrap();
+        Ok(response)
+    }
+}
+
+fn main() {
+    unreachable!("main is a stub");
+}


### PR DESCRIPTION
This commit tests the presence of the authority and scheme in the inbound http request.

The presence/absence of these fields in the inbound request is currently not finalized in the spec[1], hence why this test is expected to fail.

[1]: https://github.com/WebAssembly/WASI/issues/788