### PR TITLE
fix(docs): WAMR link

### DIFF
--- a/doc/adapters.md
+++ b/doc/adapters.md
@@ -11,7 +11,7 @@ runtime itself is.
 
 The WASI test runner includes adapters for
 [pywasm](https://github.com/mohanson/pywasm),
-[wamr](https://bytecodealliance.github.io/wamr.dev/),
+[wamr](https://groups.google.com/g/wamr-dev),
 [wasmedge](https://wasmedge.org), [wasmtime](https://wasmtime.dev),
 [wazero](https://wazero.io), and
 [wizard](https://github.com/titzer/wizard-engine/).  Contributions of


### PR DESCRIPTION
This commit fixes the WAMR link which has changed now that they have migrated to Google Groups, resolving Markdown Link check CI failures.