### PR TITLE
http: Add infrastructure for outbound http requests

### DIFF
--- a/test-runner/tests/test_test_case.py
+++ b/test-runner/tests/test_test_case.py
@@ -9,6 +9,7 @@ import pytest
 from wasi_test_runner.test_case import (
     Config, Failure, Result,
     Run, Wait, Read, Write, Connect, Send, Recv, Request, Response, Kill,
+    Endpoint, EndpointResponse,
     ProtocolType, WasiProposal, WasiWorld, TestCaseValidator
 )
 
@@ -229,6 +230,117 @@ def test_request_from_config_rejects_non_dict_headers() -> None:
 def test_request_from_config_rejects_non_str_body() -> None:
     with pytest.raises(ValueError):
         Request.from_config({"body": 123, "response": {}})
+
+
+def test_endpoint_response_from_config_str_shorthand() -> None:
+    response = EndpointResponse.from_config("hello")
+
+    assert response.status == 200
+    assert response.headers == {}
+    assert response.body == "hello"
+
+
+def test_endpoint_response_from_config_object() -> None:
+    response = EndpointResponse.from_config({
+        "status": 404,
+        "headers": {"content-type": "text/plain"},
+        "body": "nope",
+    })
+
+    assert response.status == 404
+    assert response.headers == {"content-type": "text/plain"}
+    assert response.body == "nope"
+
+
+def test_endpoint_response_from_config_rejects_non_str_non_dict() -> None:
+    with pytest.raises(ValueError, match="should be a str or an object"):
+        EndpointResponse.from_config(42)
+
+
+def test_endpoint_response_from_config_rejects_non_int_status() -> None:
+    with pytest.raises(ValueError):
+        EndpointResponse.from_config({"status": "200"})
+
+
+def test_endpoint_from_config_with_defaults() -> None:
+    endpoint = Endpoint.from_config({})
+
+    assert endpoint.method == "GET"
+    assert endpoint.path == "/"
+    assert endpoint.response == EndpointResponse(status=200, headers={}, body="")
+
+
+def test_endpoint_from_config_with_values() -> None:
+    endpoint = Endpoint.from_config({
+        "method": "PUT",
+        "path": "/greet",
+        "response": {"status": 201, "body": "hi"},
+    })
+
+    assert endpoint.method == "PUT"
+    assert endpoint.path == "/greet"
+    assert endpoint.response == EndpointResponse(status=201, headers={}, body="hi")
+
+
+def test_endpoint_from_config_uppercases_method() -> None:
+    endpoint = Endpoint.from_config({"method": "post", "path": "/greet"})
+
+    assert endpoint.method == "POST"
+
+
+def test_endpoint_from_config_rejects_unknown_method() -> None:
+    with pytest.raises(ValueError, match="Unknown endpoint method: TRACE"):
+        Endpoint.from_config({"method": "TRACE", "path": "/greet"})
+
+
+def test_endpoint_from_config_rejects_non_str_method() -> None:
+    with pytest.raises(ValueError, match="method should be a str"):
+        Endpoint.from_config({"method": 1, "path": "/greet"})
+
+
+def test_endpoint_from_config_rejects_non_str_path() -> None:
+    with pytest.raises(ValueError, match="path should be a str"):
+        Endpoint.from_config({"method": "GET", "path": 1})
+
+
+def test_endpoint_from_config_echo_path_has_no_response() -> None:
+    endpoint = Endpoint.from_config({"method": "POST", "path": "/echo"})
+
+    assert endpoint.method == "POST"
+    assert endpoint.path == "/echo"
+    assert endpoint.response is None
+
+
+def test_endpoint_from_config_echo_path_rejects_response() -> None:
+    with pytest.raises(ValueError, match="reserved echo path"):
+        Endpoint.from_config({"method": "POST", "path": "/echo", "response": "hi"})
+
+
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data='{"endpoints": [{"method": "post", "path": "/echo"},'
+              ' {"path": "/greet", "response": "hello"}]}',
+)
+def test_new_config_with_endpoints(_mock_file: Mock) -> None:
+    config = Config.from_file("file")
+
+    assert config.endpoints == [
+        Endpoint(method="POST", path="/echo", response=None),
+        Endpoint(method="GET", path="/greet",
+                 response=EndpointResponse(status=200, headers={}, body="hello")),
+    ]
+
+
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data='{"operations": [{"type": "run"}, {"type": "wait"}]}',
+)
+def test_new_config_without_endpoints(_mock_file: Mock) -> None:
+    config = Config.from_file("file")
+
+    assert config.endpoints == []
 
 
 def test_kill_from_config_with_signal() -> None:

--- a/test-runner/wasi_test_runner/test_case.py
+++ b/test-runner/wasi_test_runner/test_case.py
@@ -7,12 +7,17 @@ from typing import List, NamedTuple, TypeVar, Type, Dict, Any, Set, Optional
 
 # Top level configuration keys
 LEGACY_CONFIG_KEYS = {"args", "root", "env", "exit_code", "stderr", "stdout"}
-CONFIG_KEYS = {"operations", "proposals", "world"}
+CONFIG_KEYS = {"operations", "proposals", "world", "endpoints"}
 
 
-# Supported operations
+# Supported operations.
 SUPPORTED_OPERATIONS = {"run", "wait", "read", "write", "connect",
                         "send", "recv", "request", "kill"}
+
+# Supported http methods.
+HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
+
+ECHO_PATH = "/echo"
 
 
 class WasiWorld(StrEnum):
@@ -265,6 +270,57 @@ class Request(NamedTuple):
         return cls(method, path, response, headers, body)
 
 
+Er = TypeVar("Er", bound="EndpointResponse")
+
+
+class EndpointResponse(NamedTuple):
+    status: int = 200
+    headers: Dict[str, str] = {}
+    body: str = ""
+
+    @classmethod
+    def from_config(cls: Type[Er], config: Any) -> Er:
+        # This is a shorthand for { status: 200, body: config }
+        if isinstance(config, str):
+            return cls(body=config)
+        if not isinstance(config, dict):
+            raise ValueError("Endpoint response should be a str or an object")
+        base = Response.from_config(config)
+        return cls(status=base.status, headers=base.headers, body=base.body)
+
+
+Ep = TypeVar("Ep", bound="Endpoint")
+
+
+class Endpoint(NamedTuple):
+    method: str
+    path: str
+    response: Optional[EndpointResponse]
+
+    @classmethod
+    def from_config(cls: Type[Ep], config: Dict[str, Any]) -> Ep:
+        method = config.get("method", "GET")
+        path = config.get("path", "/")
+
+        if not isinstance(method, str):
+            raise ValueError("Endpoint method should be a str")
+        if method.upper() not in HTTP_METHODS:
+            raise ValueError(f"Unknown endpoint method: {method}")
+        if not isinstance(path, str):
+            raise ValueError("Endpoint path should be a str")
+
+        method = method.upper()
+
+        if path == ECHO_PATH:
+            if "response" in config:
+                raise ValueError(
+                    f"The reserved echo path {ECHO_PATH} takes no 'response'")
+            return cls(method=method, path=path, response=None)
+
+        response = EndpointResponse.from_config(config.get("response", ""))
+        return cls(method=method, path=path, response=response)
+
+
 K = TypeVar("K", bound="Kill")
 
 
@@ -303,6 +359,8 @@ class Config(NamedTuple):
     debug: bool = False
     # WASI world to target
     world: WasiWorld = WasiWorld.CLI_COMMAND
+    # HTTP endpoints served for outbound `wasi:http/client` requests.
+    endpoints: List[Endpoint] = []
 
     @classmethod
     def from_file(cls: Type[T], config_file: str) -> T:
@@ -310,7 +368,9 @@ class Config(NamedTuple):
             dict_config = json.load(file)
 
         test_config_path = Path(config_file)
-        if dict_config.get("operations") is not None or dict_config.get("proposals") is not None:
+        if (dict_config.get("operations") is not None
+                or dict_config.get("proposals") is not None
+                or dict_config.get("endpoints") is not None):
             cls._validate_config(dict_config, CONFIG_KEYS)
 
             operations = []
@@ -321,6 +381,10 @@ class Config(NamedTuple):
             if dict_config.get("proposals") is not None:
                 proposals = cls._proposals_from_config(dict_config.get("proposals"))
 
+            endpoints = []
+            if dict_config.get("endpoints") is not None:
+                endpoints = cls._endpoints_from_config(dict_config.get("endpoints"))
+
             world = dict_config.get("world", WasiWorld.CLI_COMMAND.value)
             if world not in WasiWorld:
                 raise ValueError(f"Unknown WASI world: {world}")
@@ -328,7 +392,7 @@ class Config(NamedTuple):
             debug = bool(dict_config.get("debug"))
 
             return cls(operations=operations, proposals=proposals,
-                       world=WasiWorld(world), debug=debug)
+                       world=WasiWorld(world), debug=debug, endpoints=endpoints)
 
         cls._validate_config(dict_config, LEGACY_CONFIG_KEYS)
 
@@ -415,6 +479,10 @@ class Config(NamedTuple):
     @classmethod
     def _proposals_from_config(cls: Type[T], proposals: List[Any]) -> List[WasiProposal]:
         return [WasiProposal(p) for p in proposals]
+
+    @classmethod
+    def _endpoints_from_config(cls: Type[T], endpoints: List[Any]) -> List[Endpoint]:
+        return [Endpoint.from_config(ep) for ep in endpoints]
 
 
 class TestCase(NamedTuple):

--- a/test-runner/wasi_test_runner/test_suite_runner.py
+++ b/test-runner/wasi_test_runner/test_suite_runner.py
@@ -5,17 +5,20 @@ import re
 import shutil
 import subprocess
 import socket
+import threading
 import time
 
 from datetime import datetime
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
-from typing import List, NamedTuple, Tuple, Dict, Any, IO
+from typing import List, NamedTuple, Optional, Tuple, Dict, Any, IO
 
 from .filters import TestFilter
 from .runtime_adapter import RuntimeAdapter
 from .test_case import (
     Result, Failure, WasiVersion, Config, Outcome,
     TestCase, TestCaseRunnerBase, TestCaseValidator,
+    EndpointResponse,
     # Operation types
     Run, Read, Write, Wait, Send, Recv, Connect, Request, Kill
 )
@@ -34,6 +37,50 @@ class _TestSpec(NamedTuple):
     config: Config
 
 
+class _EndpointServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, server_address: Tuple[str, int], handler: Any) -> None:
+        super().__init__(server_address, handler)
+        self.routes: Dict[Tuple[str, str], Optional[EndpointResponse]] = {}
+
+
+class _EndpointRequestHandler(BaseHTTPRequestHandler):
+    def _dispatch(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+        if (self.command, self.path) not in self.server.routes:  # type: ignore[attr-defined]
+            self._reply(404, {}, b"")
+            return
+        response = self.server.routes[(self.command, self.path)]  # type: ignore[attr-defined]
+        if response is None:
+            # Reserved echo path: reflect the request body back verbatim.
+            self._reply(200, {}, body)
+        else:
+            self._reply(response.status, response.headers, response.body.encode("utf-8"))
+
+    do_GET = _dispatch
+    do_POST = _dispatch
+    do_PUT = _dispatch
+    do_DELETE = _dispatch
+    do_PATCH = _dispatch
+    do_HEAD = _dispatch
+    do_OPTIONS = _dispatch
+
+    def _reply(self, status: int, headers: Dict[str, str], body: bytes) -> None:
+        self.send_response(status)
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def log_message(self, *_args: Any) -> None:
+        # Avoiding polluting stderr.
+        pass
+
+
 class TestCaseRunner(TestCaseRunnerBase):
     # pylint: disable-msg=too-many-instance-attributes
     _test_path: str
@@ -45,6 +92,8 @@ class TestCaseRunner(TestCaseRunnerBase):
     _sockets: Dict[str, socket.socket]
     _last_argv: List[str]
     _http_server: str | None
+    _endpoint_server: _EndpointServer | None
+    _endpoint_addr: str | None
     _windows_terminated_by_runner: bool
 
     def __init__(self, config: Config, test_path: str, wasi_version: WasiVersion,
@@ -59,7 +108,20 @@ class TestCaseRunner(TestCaseRunnerBase):
         self._sockets = {}
         self._last_argv = []
         self._http_server = None
+        self._endpoint_server = None
+        self._endpoint_addr = None
         self._windows_terminated_by_runner = False
+
+    def _start_endpoints(self) -> None:
+        if not self.config.endpoints or self._endpoint_server is not None:
+            return
+        server = _EndpointServer(("127.0.0.1", 0), _EndpointRequestHandler)
+        for endpoint in self.config.endpoints:
+            server.routes[(endpoint.method, endpoint.path)] = endpoint.response
+        host, port = server.server_address
+        self._endpoint_addr = f"{host}:{port}"  # noqa: E231
+        self._endpoint_server = server
+        threading.Thread(target=server.serve_forever, daemon=True).start()
 
     def _add_cleanup_dir(self, d: Path) -> None:
         _cleanup_test_output(d)
@@ -113,9 +175,13 @@ class TestCaseRunner(TestCaseRunnerBase):
     def do_run(self, run: Run) -> None:
         if run.root:
             self._add_cleanup_dir(run.root)
+        self._start_endpoints()
         proposals = self.config.proposals_as_str()
+        wasi_env = dict(run.env)
+        if self._endpoint_addr is not None:
+            wasi_env["HTTP_ENDPOINT"] = self._endpoint_addr
         argv = self._runtime.compute_argv(
-            self._test_path, run.args, run.env, run.root, proposals,
+            self._test_path, run.args, wasi_env, run.root, proposals,
             self.config.world, self._wasi_version)
         self._last_argv = argv
         try:
@@ -281,6 +347,12 @@ class TestCaseRunner(TestCaseRunnerBase):
                 self.fail_unexpected(
                     f"Timeout expired after killing proc {self._proc}")
                 self._proc = None
+
+        if self._endpoint_server is not None:
+            self._endpoint_server.shutdown()
+            self._endpoint_server.server_close()
+            self._endpoint_server = None
+            self._endpoint_addr = None
 
         for sock in self._sockets.values():
             sock.close()

--- a/tests/rust/wasm32-wasip3/BUCK
+++ b/tests/rust/wasm32-wasip3/BUCK
@@ -63,6 +63,7 @@ _RUST_P3_TESTS = [
     rust_p3_test("http-service", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("http-service-echo", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("http-service-uri", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
+    rust_p3_test("http-client", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("monotonic-clock", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("multi-clock-wait", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),
     rust_p3_test("random", deps = _RUST_P3_DEPS, wit_srcs = _WIT_SRCS),

--- a/tests/rust/wasm32-wasip3/src/bin/http-client.json
+++ b/tests/rust/wasm32-wasip3/src/bin/http-client.json
@@ -1,0 +1,16 @@
+{
+  "proposals": ["http"],
+  "world": "wasi:http/service",
+  "endpoints": [
+    { "method": "POST", "path": "/echo" }
+  ],
+  "operations": [
+    { "type": "run" },
+    { "type": "request",
+      "method": "GET",
+      "path": "/",
+      "response": { "status": 200 } },
+    { "type": "kill", "signal": "SIGINT" },
+    { "type": "wait" }
+  ]
+}

--- a/tests/rust/wasm32-wasip3/src/bin/http-client.rs
+++ b/tests/rust/wasm32-wasip3/src/bin/http-client.rs
@@ -1,0 +1,73 @@
+use test_wasm32_wasip3::http::wasi::cli::environment;
+use test_wasm32_wasip3::http::wasi::http::client;
+use test_wasm32_wasip3::http::wasi::http::types::{
+    ErrorCode, Fields, Method, Request, Response, Scheme,
+};
+use test_wasm32_wasip3::http::{export, exports::wasi::http::handler::Guest};
+use test_wasm32_wasip3::http::{wit_future, wit_stream};
+
+fn endpoint_authority() -> String {
+    environment::get_environment()
+        .into_iter()
+        .find(|(name, _)| name == "HTTP_ENDPOINT")
+        .map(|(_, value)| value)
+        .expect("HTTP_ENDPOINT must be set by the test runner")
+}
+
+async fn read_body(response: Response) -> Vec<u8> {
+    let (_, result_rx) = wit_future::new(|| Ok(()));
+    let (body_rx, trailers) = Response::consume_body(response, result_rx);
+    let body = body_rx.collect().await;
+    assert!(trailers.await.unwrap().is_none());
+    body
+}
+
+struct Component;
+export!(Component);
+
+impl Guest for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let authority = endpoint_authority();
+        let payload = b"ping".to_vec();
+
+        let headers = Fields::new();
+        headers
+            .append("content-length", payload.len().to_string().as_bytes())
+            .unwrap();
+
+        let (mut body_tx, body_rx) = wit_stream::new();
+        let sent_bytes = payload.clone();
+        wit_bindgen::spawn_local(async move {
+            let remaining = body_tx.write_all(sent_bytes).await;
+            assert!(remaining.is_empty());
+            drop(body_tx);
+        });
+
+        let (trailers_tx, trailers_rx) = wit_future::new(|| Ok(None));
+        drop(trailers_tx);
+
+        let (request, _sent) = Request::new(headers, Some(body_rx), trailers_rx, None);
+        request.set_method(&Method::Post).unwrap();
+        request.set_scheme(Some(&Scheme::Http)).unwrap();
+        request.set_authority(Some(&authority)).unwrap();
+        request.set_path_with_query(Some("/echo")).unwrap();
+
+        let response = client::send(request).await.expect("send should succeed");
+        assert_eq!(
+            read_body(response).await,
+            payload,
+            "endpoint must echo the body"
+        );
+
+        let headers = Fields::new();
+        let (trailers_tx, trailers_rx) = wit_future::new(|| Ok(None));
+        drop(trailers_tx);
+        let (response, _sent) = Response::new(headers, None, trailers_rx);
+        response.set_status_code(200).unwrap();
+        Ok(response)
+    }
+}
+
+fn main() {
+    unreachable!("main is a stub");
+}

--- a/tests/rust/wasm32-wasip3/src/http.rs
+++ b/tests/rust/wasm32-wasip3/src/http.rs
@@ -4,6 +4,7 @@ wit_bindgen::generate!({
 
 	world http-test {
 	    include wasi:http/service@0.3.0;
+	    import wasi:cli/environment@0.3.0;
 	}
     ",
     additional_derives: [PartialEq, Eq, Hash, Clone],


### PR DESCRIPTION
This commit adds the base infrastructure for outbound http requests; this will enable testing the http client interface.

This patch introduces a new configuration option: `endpoints`, from which the runner sets up an http server with the routing and payload metadata.